### PR TITLE
vault: `vault mount` is now `vault secrets enable`

### DIFF
--- a/docker-compose/vault/entry.sh
+++ b/docker-compose/vault/entry.sh
@@ -31,7 +31,7 @@ else
     done
     echo -n `grep 'Unseal Key: ' $HOME/logfile | awk '{print $NF}' | sed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g"` > /vault/file/unseal
     echo "bootstrapping our transit key"
-    VAULT_TOKEN=$VAULT_DEV_ROOT_TOKEN_ID vault mount transit
+    VAULT_TOKEN=$VAULT_DEV_ROOT_TOKEN_ID vault secrets enable transit
     VAULT_TOKEN=$VAULT_DEV_ROOT_TOKEN_ID vault write transit/restore/cabotage-app backup=`cat /etc/vault/cabotage-vault-key.backup`
     echo "bootstrapping postgres stufffff"
     VAULT_TOKEN=$VAULT_DEV_ROOT_TOKEN_ID vault secrets enable database


### PR DESCRIPTION
I noticed this while working on integrating Vault into Warehouse directly for TUF: `vault mount` no longer exists (as of _at least_ 1.3.4) and has been replaced with `vault secrets enable`. I'm guessing this codepath hasn't been hit in a while, which might be why it wasn't caught.