### PR TITLE
release_build_context: put XDG dirs in template

### DIFF
--- a/cabotage/utils/release_build_context.py
+++ b/cabotage/utils/release_build_context.py
@@ -1,16 +1,16 @@
 import kubernetes
 
-# NOTE: Because we run the entrypoint as `nobody` with a `/nonexistent`
-# home directory, we need to explicitly configure some XDG directories
-# for applications that expect to cache/maintain state in them.
-# This needs to happen *after* the `USER` directive so that `nobody`
-# has the right permissions to access them.
 RELEASE_DOCKERFILE_TEMPLATE = """
 FROM {registry}/{image.repository_name}:image-{image.version}
 COPY --from=hashicorp/envconsul:0.13.1 /bin/envconsul /usr/bin/envconsul
 COPY --chown=root:root --chmod=755 entrypoint.sh /entrypoint.sh
 {process_commands}
 USER nobody
+# NOTE: Because we run the entrypoint as `nobody` with a `/nonexistent`
+# home directory, we need to explicitly configure some XDG directories
+# for applications that expect to cache/maintain state in them.
+# This needs to happen *after* the `USER` directive so that `nobody`
+# has the right permissions to access them.
 RUN mkdir -p /tmp/share /tmp/cache
 ENV XDG_DATA_HOME /tmp/share
 ENV XDG_CACHE_HOME /tmp/cache

--- a/cabotage/utils/release_build_context.py
+++ b/cabotage/utils/release_build_context.py
@@ -1,11 +1,19 @@
 import kubernetes
 
+# NOTE: Because we run the entrypoint as `nobody` with a `/nonexistent`
+# home directory, we need to explicitly configure some XDG directories
+# for applications that expect to cache/maintain state in them.
+# This needs to happen *after* the `USER` directive so that `nobody`
+# has the right permissions to access them.
 RELEASE_DOCKERFILE_TEMPLATE = """
 FROM {registry}/{image.repository_name}:image-{image.version}
 COPY --from=hashicorp/envconsul:0.13.1 /bin/envconsul /usr/bin/envconsul
 COPY --chown=root:root --chmod=755 entrypoint.sh /entrypoint.sh
 {process_commands}
 USER nobody
+RUN mkdir -p /tmp/share /tmp/cache
+ENV XDG_DATA_HOME /tmp/share
+ENV XDG_CACHE_HOME /tmp/cache
 ENTRYPOINT ["/entrypoint.sh"]
 CMD []
 """


### PR DESCRIPTION
See previous discussion in https://github.com/pypi/warehouse/pull/16304 🙂 

NB: I'm going to open a PR on Warehouse (https://github.com/pypi/warehouse/pull/16322) that should improve the backstop test for this. My suggestion is to wait on merging here until that goes in first.

### Description

This adds `XDG_DATA_HOME` and `XDG_CACHE_HOME` to the wrapper layer in Cabotage, injecting appropriate temporary directories for both of these even when `USER=nobody` and `HOME=/nonexistent`.

This needs to happen after the `USER` directive, to ensure that `USER=nobody` has appropriate R/W access to these directories.

### Review request

CC @ewdurbin @di

### Breaking changes

No breaking change (in theory).