### PR TITLE
Revert "Update `datadog/agent` image to 7.55.2 (#88)"

### DIFF
--- a/cabotage/server/config.py
+++ b/cabotage/server/config.py
@@ -81,4 +81,4 @@ class Config(metaclass=MetaFlaskEnv):
     GITHUB_WEBHOOK_SECRET = None
     SHELLZ_ENABLED = False
     SIDECAR_IMAGE = "cabotage/sidecar:3"
-    DATADOG_IMAGE = "datadog/agent:7.55.2"
+    DATADOG_IMAGE = "datadog/agent:7.37.1"


### PR DESCRIPTION
This reverts commit 9d744b3c57a6a52fb7d568380cab55a691d75ab6.