### PR TITLE
upgrade Datadog Agent

### DIFF
--- a/cabotage/celery/tasks/deploy.py
+++ b/cabotage/celery/tasks/deploy.py
@@ -521,7 +521,7 @@ def render_datadog_container(dd_api_key, datadog_tags):
                 name="DD_HOSTNAME",
                 value_from=kubernetes.client.V1EnvVarSource(
                     field_ref=kubernetes.client.V1ObjectFieldSelector(
-                        api_version="1", field_path="spec.nodeName"
+                        api_version="v1", field_path="spec.nodeName"
                     )
                 ),
             ),

--- a/cabotage/celery/tasks/deploy.py
+++ b/cabotage/celery/tasks/deploy.py
@@ -517,10 +517,50 @@ def render_datadog_container(dd_api_key, datadog_tags):
         image_pull_policy="IfNotPresent",
         env=[
             kubernetes.client.V1EnvVar(name="DD_API_KEY", value=dd_api_key),
-            kubernetes.client.V1EnvVar(name="DD_LOGS_ENABLED", value="false"),
+            kubernetes.client.V1EnvVar(
+                name="DD_HOSTNAME",
+                value_from=kubernetes.client.V1EnvVarSource(
+                    field_ref=kubernetes.client.V1ObjectFieldSelector(
+                        api_version="1", field_path="spec.nodeName"
+                    )
+                ),
+            ),
             kubernetes.client.V1EnvVar(
                 name="DD_DOGSTATSD_TAGS",
                 value=" ".join([f"{k}:{v}" for k, v in datadog_tags.items()]),
+            ),
+            kubernetes.client.V1EnvVar(
+                name="DD_TAGS",
+                value=" ".join([f"{k}:{v}" for k, v in datadog_tags.items()]),
+            ),
+            kubernetes.client.V1EnvVar(name="DD_USE_DOGSTATSD", value="true"),
+            kubernetes.client.V1EnvVar(name="DD_APM_ENABLED", value="true"),
+            kubernetes.client.V1EnvVar(name="DD_LOGS_ENABLED", value="false"),
+            kubernetes.client.V1EnvVar(name="DD_CONFD_PATH", value="/tmp/null"),
+            kubernetes.client.V1EnvVar(
+                name="DD_AUTOCONF_TEMPLATE_DIR", value="/tmp/null"
+            ),
+            kubernetes.client.V1EnvVar(name="DD_ENABLE_GOHAI", value="false"),
+            kubernetes.client.V1EnvVar(
+                name="DD_COLLECT_KUBERNETES_EVENTS", value="false"
+            ),
+            kubernetes.client.V1EnvVar(
+                name="DD_ENABLE_METADATA_COLLECTION", value="false"
+            ),
+            kubernetes.client.V1EnvVar(name="DD_ENABLE_PAYLOADS_EVENTS", value="true"),
+            kubernetes.client.V1EnvVar(name="DD_ENABLE_PAYLOADS_SERIES", value="true"),
+            kubernetes.client.V1EnvVar(
+                name="DD_ENABLE_PAYLOADS_SERVICE_CHECKS", value="false"
+            ),
+            kubernetes.client.V1EnvVar(
+                name="DD_ENABLE_PAYLOADS_SKETCHES", value="false"
+            ),
+            kubernetes.client.V1EnvVar(
+                name="DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED", value="false"
+            ),
+            kubernetes.client.V1EnvVar(
+                name="DD_AUTOCONFIG_EXCLUDE_FEATURES",
+                value="cloudfoundry cri docker ecsec2 ecsfargate eksfargate kubernetes orchestratorexplorer podman",
             ),
         ],
         resources=kubernetes.client.V1ResourceRequirements(

--- a/cabotage/celery/tasks/deploy.py
+++ b/cabotage/celery/tasks/deploy.py
@@ -536,9 +536,11 @@ def render_datadog_container(dd_api_key, datadog_tags):
             kubernetes.client.V1EnvVar(name="DD_USE_DOGSTATSD", value="true"),
             kubernetes.client.V1EnvVar(name="DD_APM_ENABLED", value="true"),
             kubernetes.client.V1EnvVar(name="DD_LOGS_ENABLED", value="false"),
-            kubernetes.client.V1EnvVar(name="DD_CONFD_PATH", value="/tmp/null"),
             kubernetes.client.V1EnvVar(
-                name="DD_AUTOCONF_TEMPLATE_DIR", value="/tmp/null"
+                name="DD_CONFD_PATH", value="/tmp/null"  # nosec
+            ),
+            kubernetes.client.V1EnvVar(
+                name="DD_AUTOCONF_TEMPLATE_DIR", value="/tmp/null"  # nosec
             ),
             kubernetes.client.V1EnvVar(name="DD_ENABLE_GOHAI", value="false"),
             kubernetes.client.V1EnvVar(

--- a/cabotage/server/config.py
+++ b/cabotage/server/config.py
@@ -81,4 +81,4 @@ class Config(metaclass=MetaFlaskEnv):
     GITHUB_WEBHOOK_SECRET = None
     SHELLZ_ENABLED = False
     SIDECAR_IMAGE = "cabotage/sidecar:3"
-    DATADOG_IMAGE = "datadog/agent:7.37.1"
+    DATADOG_IMAGE = "datadog/agent:7.55.2"


### PR DESCRIPTION
### Description

This upgrades the datadog agent sidecar to datadog/agent:7.55.2

It also includes an enormous number of configurations necessary to minimize the agents configuration.

Ultimately the goal is _just_ to run the dogstatsd and APM listeners