### PR TITLE
set DD hostname to pod name, not node name

### DIFF
--- a/cabotage/celery/tasks/deploy.py
+++ b/cabotage/celery/tasks/deploy.py
@@ -521,7 +521,7 @@ def render_datadog_container(dd_api_key, datadog_tags):
                 name="DD_HOSTNAME",
                 value_from=kubernetes.client.V1EnvVarSource(
                     field_ref=kubernetes.client.V1ObjectFieldSelector(
-                        api_version="v1", field_path="spec.nodeName"
+                        api_version="v1", field_path="metadata.name"
                     )
                 ),
             ),


### PR DESCRIPTION
### Description

Set hostname in DD sidecar to the pod name (container), not the node name (host).