### PR TITLE
deployments: return from DeployError except

### DIFF
--- a/cabotage/celery/tasks/deploy.py
+++ b/cabotage/celery/tasks/deploy.py
@@ -1139,7 +1139,7 @@ def deploy_release(deployment):
                 access_token,
                 deployment.deploy_metadata["statuses_url"],
                 "failure",
-                "Deployment failed: {exc}",
+                f"Deployment failed: {exc}",
             )
         deployment.deploy_log = "\n".join(deploy_log)
         db.session.commit()
@@ -1159,7 +1159,7 @@ def deploy_release(deployment):
                 access_token,
                 deployment.deploy_metadata["statuses_url"],
                 "failure",
-                "Deployment failed: {exc}",
+                f"Deployment failed: {exc}",
             )
         deployment.deploy_log = "\n".join(deploy_log)
         db.session.commit()

--- a/cabotage/celery/tasks/deploy.py
+++ b/cabotage/celery/tasks/deploy.py
@@ -1141,6 +1141,9 @@ def deploy_release(deployment):
                 "failure",
                 "Deployment failed: {exc}",
             )
+        deployment.deploy_log = "\n".join(deploy_log)
+        db.session.commit()
+        return False
     except Exception as exc:
         deployment.error = True
         deployment.error_detail = f"Unexpected Error: {str(exc)}"


### PR DESCRIPTION
when deployments fail in cabotage, GitHub API is correctly notified, but due to a lack of a return the success clause happens too.

this obscures the failed deployment in views on GitHub as well as in the Slack integration.