### PR TITLE
Implement Rollbacks in the UI

### DIFF
--- a/cabotage/client/templates/user/application_releases.html
+++ b/cabotage/client/templates/user/application_releases.html
@@ -4,7 +4,7 @@
   <div class="container" id="content">
     <div class="row">
       <div class="col-md-8">
-        <h3>Images</h3>
+        <h3>Releases</h3>
         <table class="table table-striped">
           <tr>
             <th>Version</th>

--- a/cabotage/client/templates/user/application_releases.html
+++ b/cabotage/client/templates/user/application_releases.html
@@ -10,6 +10,7 @@
             <th>Version</th>
             <th>Built</th>
             <th>Updated</th>
+            <th>Status</th>
             <th style="white-space: nowrap; width: 1%;">Details</th>
           </tr>
           {% for release in releases %}
@@ -26,6 +27,17 @@
             <td><span class="glyphicon glyphicon-question-sign text-info"></span></td>
             {% endif %}
             <td>{{ release.updated |humanize }}</td>
+            {% if release.valid %}
+              {% if release.built %}
+              <td><span class="glyphicon glyphicon glyphicon-ok-sign text-success"></span> Built</td>
+              {% elif release.error %}
+              <td><span class="glyphicon glyphicon-exclamation-sign text-danger"></span> Error</td>
+              {% else %}
+              <td><span class="glyphicon glyphicon-question-sign text-info"></span> Building...</td>
+              {% endif %}
+            {% else %}
+              <td><span class="glyphicon glyphicon-exclamation-sign text-danger"></span> Release Invalid!</td>
+            {% endif %}
             <td><a class="btn btn-info" href="{{ url_for('user.release_detail', release_id=release.id) }}"><span class="glyphicon glyphicon-search"></a></td>
           </tr>
           {% endfor %}

--- a/cabotage/client/templates/user/project_application.html
+++ b/cabotage/client/templates/user/project_application.html
@@ -61,6 +61,8 @@
             <th>Status</th>
             <th>Started</th>
             <th>Updated</th>
+            <th>Release</th>
+            <th>Options</th>
             <th style="white-space: nowrap; width: 1%;">Details</th>
           </tr>
           {% for deployment in application.recent_deployments %}
@@ -75,6 +77,10 @@
 
             <td>{{ deployment.created |humanize }}</td>
             <td>{{ deployment.updated |humanize }}</td>
+            <td><code>{{ deployment.release_object.version }}</code></td>
+            <td>
+              {% if deployment.release_object.valid and deployment.release_object != application.latest_deployment_completed.release_object %}<a class="btn btn-info" title="Rollback to this release" href="{{ url_for('user.release_deploy', release_id=deployment.release_object.id, rollback=True) }}"><span class="glyphicon glyphicon-repeat"></span></a>{% endif %}
+            </td>
             <td><a class="btn btn-info" href="{{ url_for('user.deployment_detail', deployment_id=deployment.id) }}"><span class="glyphicon glyphicon-search"></a></td>
           </tr>
           {% endfor %}

--- a/cabotage/client/templates/user/project_application.html
+++ b/cabotage/client/templates/user/project_application.html
@@ -15,6 +15,7 @@
         {% if application.latest_release.built %}
         <form action="{{ url_for('user.release_deploy', release_id=application.latest_release.id) }}" method="POST" name="deploy_release_form" enctype="multipart/form-data">
           {{ deploy_form.hidden_tag() }}
+          <input class="form-control" id="release_id" name="release_id" required="" type="text" value="{{ application.latest_release.id }}" style="display: none">
           <div class="row">
             <div class="col-md-6">
               {{ form_button(deploy_form.submit, "Do It!", method="POST", class="btn btn-primary") }}

--- a/cabotage/client/templates/user/release_deploy.html
+++ b/cabotage/client/templates/user/release_deploy.html
@@ -1,0 +1,21 @@
+{% extends "_base.html" %}
+{% from "security/_macros.html" import render_field_with_errors, render_field %}
+{% from "bootstrap/wtf.html" import form_errors, form_field %}
+{% from "bootstrap/utils.html" import form_button %}
+
+{% block content %}
+{% include "security/_messages.html" %}
+<div class="container-fluid clearfix" id="content">
+  <div class="row">
+    <div class="col-md-4 col-md-offset-4 col-sm-8 col-xs-8 col-xs-offset-2 col-sm-offset-2">
+      <h1>Deploy Release</h1>
+      <form action="{{ url_for('user.release_deploy', release_id=release.id) }}" method="POST" name="release_deploy">
+        {{ deploy_form.hidden_tag() }}
+        {{ form_field(deploy_form.release_id, disabled="disabled") }}
+        {{ form_field(deploy_form.is_rollback, disabled=True) }}
+        {{ form_button(deploy_form.submit, "Create", method="POST", class="btn btn-primary") }}
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/cabotage/server/models/projects.py
+++ b/cabotage/server/models/projects.py
@@ -252,13 +252,13 @@ class Application(db.Model, Timestamp):
 
     @property
     def latest_deployment(self):
-        return self.deployments.filter_by().order_by(Deployment.version.desc()).first()
+        return self.deployments.filter_by().order_by(Deployment.created.desc()).first()
 
     @property
     def latest_deployment_completed(self):
         return (
             self.deployments.filter_by(complete=True)
-            .order_by(Deployment.version.desc())
+            .order_by(Deployment.created.desc())
             .first()
         )
 
@@ -266,7 +266,7 @@ class Application(db.Model, Timestamp):
     def latest_deployment_error(self):
         return (
             self.deployments.filter_by(error=True)
-            .order_by(Deployment.version.desc())
+            .order_by(Deployment.created.desc())
             .first()
         )
 
@@ -274,7 +274,7 @@ class Application(db.Model, Timestamp):
     def latest_deployment_running(self):
         return (
             self.deployments.filter_by(complete=False, error=False)
-            .order_by(Deployment.version.desc())
+            .order_by(Deployment.created.desc())
             .first()
         )
 

--- a/cabotage/server/models/projects.py
+++ b/cabotage/server/models/projects.py
@@ -377,6 +377,9 @@ class Deployment(db.Model, Timestamp):
         nullable=False,
     )
     release = db.Column(postgresql.JSONB(), nullable=False)
+    is_rollback = db.Column(
+        db.Boolean, nullable=False, default=False, server_default="false"
+    )
     version_id = db.Column(db.Integer, nullable=False)
     complete = db.Column(db.Boolean, nullable=False, default=False)
     error = db.Column(db.Boolean, nullable=False, default=False)

--- a/cabotage/server/user/forms.py
+++ b/cabotage/server/user/forms.py
@@ -411,7 +411,7 @@ class DeleteConfigurationForm(FlaskForm):
 class ReleaseDeployForm(FlaskForm):
     release_id = StringField(
         "Release ID",
-        [InputRequired()],
+        [DataRequired()],
         description="Release to deploy.",
     )
 

--- a/cabotage/server/user/forms.py
+++ b/cabotage/server/user/forms.py
@@ -414,6 +414,11 @@ class ReleaseDeployForm(FlaskForm):
         [DataRequired()],
         description="Release to deploy.",
     )
+    is_rollback = BooleanField(
+        "Rollback",
+        [],
+        description="Deployment is a rollback",
+    )
 
 
 class ApplicationScaleForm(FlaskForm):

--- a/cabotage/server/user/views.py
+++ b/cabotage/server/user/views.py
@@ -1503,13 +1503,14 @@ def release_deploy(release_id):
         abort(403)
 
     form = ReleaseDeployForm(
-        release_id=release.id
+        release_id=release.id, is_rollback=request.args.get("rollback")
     )
 
     if form.validate_on_submit():
         deployment = Deployment(
             application_id=release.application.id,
             release=release.asdict,
+            is_rollback=form.is_rollback.data,
         )
         db.session.add(deployment)
         db.session.flush()

--- a/migrations/versions/ce4b12a41a31_add_is_rollback_to_deployment.py
+++ b/migrations/versions/ce4b12a41a31_add_is_rollback_to_deployment.py
@@ -1,0 +1,32 @@
+"""Add boolean is_rollback to Deployment
+
+Revision ID: ce4b12a41a31
+Revises: 088fc773e9fe
+Create Date: 2024-09-25 18:35:41.119747
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "ce4b12a41a31"
+down_revision = "088fc773e9fe"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "deployments",
+        sa.Column("is_rollback", sa.Boolean(), nullable=False, server_default="false"),
+    )
+    op.add_column(
+        "deployments_version",
+        sa.Column("is_rollback", sa.Boolean(), autoincrement=False, nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_column("deployments_version", "is_rollback")
+    op.drop_column("deployments", "is_rollback")


### PR DESCRIPTION
### Description

Implement rollbacks in the UI. End goal is a button that allows us to rollback _code only_ skipping release and postdeploy commands.

TODO:

- [ ] Update the release_deploy form/page to hide the specific details and just render "are you sure you want to..." with information on what's about to happen
- [ ] If a Deployment.is_rollback, then skip the [release](https://github.com/cabotage/cabotage-app/blob/1186e326c99e06f765fd59b4317884a138244986/cabotage/celery/tasks/deploy.py#L1045-L1064) and [postdeploy](https://github.com/cabotage/cabotage-app/blob/1186e326c99e06f765fd59b4317884a138244986/cabotage/celery/tasks/deploy.py#L1105-L1124) steps during deploy workflow.