### PR TITLE
infra: add migration generation target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 	lint reformat type-check security-check \
 	start stop rebuild destroy \
 	migrate create-admin \
-	routes
+	routes migrations
 
 default:
 	@echo "Call a specific subcommand:"
@@ -24,6 +24,9 @@ stop:
 
 destroy:
 	docker-compose down --volumes
+
+migrations:
+	docker-compose exec cabotage-app python3 -m flask db revision --autogenerate -m "$(filter-out $@,$(MAKECMDGOALS))"
 
 migrate:
 	docker-compose exec cabotage-app python3 -m flask db upgrade


### PR DESCRIPTION
<!--  Thank you for sending a pull request! Please take a moment to answer the following questions:
- Have you read our [general contributing guide](./CONTRIBUTING.md)?
- Have you added or run the appropriate tests?
- Do the commit messages and bodies explain what and why?
- If your PR is not finished, please mark it as a draft.
☝️ Please **have another look at the files changed** before opening this PR. 🙏
-->

### Description

<!-- Please include a summary of the changes and the related issues. List any dependencies that are required for this change. -->
Adds Make target to generate new migrations with an arbitrary message

<details>
<summary>Details</summary>


```
cabotage-app on  roll [📝✓] via 🐋 orbstack via  pyenv (cabotage-app) on ☁️  (us-east-2) 
✗ make migrations "cool migration"
docker-compose exec cabotage-app python3 -m flask db revision --autogenerate -m "cool migration"
patching kubernetes.watch.watch.iter_resp_lines
patched kubernetes.watch.watch.iter_resp_lines 🙈
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.autogenerate.compare] Detected removed table 'resources_certificate'
INFO  [alembic.autogenerate.compare] Detected removed table 'resources_postgres'
INFO  [alembic.autogenerate.compare] Detected removed table 'resources_redis'
INFO  [alembic.autogenerate.compare] Detected removed table 'resources_ingress'
INFO  [alembic.autogenerate.compare] Detected removed index 'ix_resources_certificate_version_end_transaction_id' on 'resources_certificate_version'
INFO  [alembic.autogenerate.compare] Detected removed index 'ix_resources_certificate_version_operation_type' on 'resources_certificate_version'
INFO  [alembic.autogenerate.compare] Detected removed index 'ix_resources_certificate_version_transaction_id' on 'resources_certificate_version'
INFO  [alembic.autogenerate.compare] Detected removed table 'resources_certificate_version'
INFO  [alembic.autogenerate.compare] Detected removed index 'ix_resources_version_end_transaction_id' on 'resources_version'
INFO  [alembic.autogenerate.compare] Detected removed index 'ix_resources_version_operation_type' on 'resources_version'
INFO  [alembic.autogenerate.compare] Detected removed index 'ix_resources_version_transaction_id' on 'resources_version'
INFO  [alembic.autogenerate.compare] Detected removed table 'resources_version'
INFO  [alembic.autogenerate.compare] Detected removed index 'ix_resources_redis_version_end_transaction_id' on 'resources_redis_version'
INFO  [alembic.autogenerate.compare] Detected removed index 'ix_resources_redis_version_operation_type' on 'resources_redis_version'
INFO  [alembic.autogenerate.compare] Detected removed index 'ix_resources_redis_version_transaction_id' on 'resources_redis_version'
INFO  [alembic.autogenerate.compare] Detected removed table 'resources_redis_version'
INFO  [alembic.autogenerate.compare] Detected removed table 'resources'
INFO  [alembic.autogenerate.compare] Detected removed index 'ix_resources_ingress_version_end_transaction_id' on 'resources_ingress_version'
INFO  [alembic.autogenerate.compare] Detected removed index 'ix_resources_ingress_version_operation_type' on 'resources_ingress_version'
INFO  [alembic.autogenerate.compare] Detected removed index 'ix_resources_ingress_version_transaction_id' on 'resources_ingress_version'
INFO  [alembic.autogenerate.compare] Detected removed table 'resources_ingress_version'
INFO  [alembic.autogenerate.compare] Detected removed index 'ix_resources_postgres_version_end_transaction_id' on 'resources_postgres_version'
INFO  [alembic.autogenerate.compare] Detected removed index 'ix_resources_postgres_version_operation_type' on 'resources_postgres_version'
INFO  [alembic.autogenerate.compare] Detected removed index 'ix_resources_postgres_version_transaction_id' on 'resources_postgres_version'
INFO  [alembic.autogenerate.compare] Detected removed table 'resources_postgres_version'
INFO  [alembic.ddl.postgresql] Detected sequence named 'activity_id_seq' as owned by integer column 'activity(id)', assuming SERIAL and omitting
INFO  [alembic.ddl.postgresql] Detected sequence named 'transaction_id_seq' as owned by integer column 'transaction(id)', assuming SERIAL and omitting
  Generating /opt/cabotage-app/src/migrations/versions/c84a45cbb991_cool_migration.py ...  done
```

</details>

### Reference to issue

<!-- Link to the relevant Issue this PR resolves. Format: Fixes #(issue number) --> 
Closes #103

### Review request

<!-- If known, add @mentions of the person or team responsible for reviewing proposed changes. -->

### Breaking changes

<!-- Does this PR introduce any breaking changes? If so, list which ones -->
