### PR TITLE
migrate to modern initcontainer based sidecars

### DIFF
--- a/cabotage/celery/tasks/deploy.py
+++ b/cabotage/celery/tasks/deploy.py
@@ -337,6 +337,7 @@ def render_cabotage_sidecar_container(release, with_tls=True):
         args.append(f"--vault-pki-role={role_name}")
     return kubernetes.client.V1Container(
         name="cabotage-sidecar",
+        restart_policy="Always",
         image=current_app.config["SIDECAR_IMAGE"],
         image_pull_policy="IfNotPresent",
         args=args,
@@ -431,6 +432,7 @@ def render_cabotage_sidecar_tls_container(release, unix=True, tcp=False):
         )
     return kubernetes.client.V1Container(
         name="cabotage-sidecar-tls",
+        restart_policy="Always",
         image=current_app.config["SIDECAR_IMAGE"],
         image_pull_policy="IfNotPresent",
         command=["/usr/bin/ghostunnel"],
@@ -533,6 +535,7 @@ def render_process_container(
 def render_datadog_container(dd_api_key, datadog_tags):
     return kubernetes.client.V1Container(
         name="dogstatsd-sidecar",
+        restart_policy="Always",
         image=current_app.config["DATADOG_IMAGE"],
         image_pull_policy="IfNotPresent",
         env=[
@@ -622,6 +625,7 @@ def render_podspec(release, process_name, service_account_name):
     init_containers = []
     containers = []
     restart_policy = None
+
     if process_name.startswith("web"):
         volumes.append(
             kubernetes.client.V1Volume(
@@ -634,8 +638,12 @@ def render_podspec(release, process_name, service_account_name):
         init_containers.append(
             render_cabotage_enroller_container(release, process_name, with_tls=True)
         )
-        containers.append(render_cabotage_sidecar_container(release, with_tls=True))
-        containers.append(render_cabotage_sidecar_tls_container(release, unix=True))
+        init_containers.append(
+            render_cabotage_sidecar_container(release, with_tls=True)
+        )
+        init_containers.append(
+            render_cabotage_sidecar_tls_container(release, unix=True)
+        )
         containers.append(
             render_process_container(
                 release, process_name, datadog_tags, with_tls=True, unix=True
@@ -645,8 +653,10 @@ def render_podspec(release, process_name, service_account_name):
         init_containers.append(
             render_cabotage_enroller_container(release, process_name, with_tls=True)
         )
-        containers.append(render_cabotage_sidecar_container(release, with_tls=True))
-        containers.append(
+        init_containers.append(
+            render_cabotage_sidecar_container(release, with_tls=True)
+        )
+        init_containers.append(
             render_cabotage_sidecar_tls_container(release, unix=False, tcp=True)
         )
         containers.append(
@@ -658,7 +668,9 @@ def render_podspec(release, process_name, service_account_name):
         init_containers.append(
             render_cabotage_enroller_container(release, process_name, with_tls=False)
         )
-        containers.append(render_cabotage_sidecar_container(release, with_tls=False))
+        init_containers.append(
+            render_cabotage_sidecar_container(release, with_tls=False)
+        )
         containers.append(
             render_process_container(
                 release, process_name, datadog_tags, with_tls=False, unix=False
@@ -707,7 +719,7 @@ def render_podspec(release, process_name, service_account_name):
         except KeyError:
             print("unable to read DD_API_KEY")
         if dd_api_key:
-            containers.append(render_datadog_container(dd_api_key, datadog_tags))
+            init_containers.append(render_datadog_container(dd_api_key, datadog_tags))
 
     return kubernetes.client.V1PodSpec(
         service_account_name=service_account_name,


### PR DESCRIPTION
Kuberentes 1.29 adds support for sidecar containers that can be ensured to be started/running before the main container is up _and_ be stopped after.

See https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/#sidecar-containers-and-pod-lifecycle

This is helpful to ensure that our tls cert/termination is available through the life of a pod and may help to ensure that datadog stats near the very begginning and very end of a pod (first/last 10s) have a chance to be captured/flushed respectively.