### PR TITLE
improve build image cache clearing job, use buildctl prune directly

### DIFF
--- a/cabotage/celery/tasks/build.py
+++ b/cabotage/celery/tasks/build.py
@@ -64,6 +64,7 @@ def build_release_buildkit(release):
     registry_ca = current_app.config["REGISTRY_VERIFY"]
     buildkitd_url = current_app.config["BUILDKITD_URL"]
     buildkitd_ca = current_app.config["BUILDKITD_VERIFY"]
+    buildkit_image = current_app.config["BUILDKIT_IMAGE"]
 
     process_commands = "\n".join(
         [
@@ -192,7 +193,7 @@ def build_release_buildkit(release):
                             containers=[
                                 kubernetes.client.V1Container(
                                     name="build",
-                                    image="moby/buildkit:v0.18.2-rootless",
+                                    image=buildkit_image,
                                     command=buildctl_command,
                                     args=buildctl_args,
                                     env=[
@@ -482,6 +483,7 @@ def build_image_buildkit(image=None):
     registry_ca = current_app.config["REGISTRY_VERIFY"]
     buildkitd_url = current_app.config["BUILDKITD_URL"]
     buildkitd_ca = current_app.config["BUILDKITD_VERIFY"]
+    buildkit_image = current_app.config["BUILDKIT_IMAGE"]
 
     access_token = None
 
@@ -730,7 +732,7 @@ def build_image_buildkit(image=None):
                             containers=[
                                 kubernetes.client.V1Container(
                                     name="build",
-                                    image="moby/buildkit:v0.18.2-rootless",
+                                    image=buildkit_image,
                                     command=buildctl_command,
                                     args=buildctl_args,
                                     env=[

--- a/cabotage/server/config.py
+++ b/cabotage/server/config.py
@@ -72,6 +72,7 @@ class Config(metaclass=MetaFlaskEnv):
     REGISTRY_AUTH_SECRET = "v3rys3cur3"  # nosec
     BUILDKITD_URL = "tcp://cabotage-buildkitd:1234"
     BUILDKITD_VERIFY = None
+    BUILDKIT_IMAGE = "moby/buildkit:v0.18.2-rootless"
     CELERY_BROKER_URL = ("redis://redis:6379",)
     CELERY_RESULT_BACKEND = "redis://redis:6379"
     KUBERNETES_ENABLED = False


### PR DESCRIPTION
### Description

Updates our build cache clearing job to use `buildctl prune --all` which will be comprehensive.