### PR TITLE
add fsGroup parameter for jobs/pods that use the buildcache

### DIFF
--- a/cabotage/celery/tasks/build.py
+++ b/cabotage/celery/tasks/build.py
@@ -759,6 +759,7 @@ def build_image_buildkit(image=None):
                                         ),
                                         run_as_user=1000,
                                         run_as_group=1000,
+                                        fs_group=1000,
                                     ),
                                     volume_mounts=[
                                         kubernetes.client.V1VolumeMount(

--- a/cabotage/server/user/views.py
+++ b/cabotage/server/user/views.py
@@ -1368,6 +1368,7 @@ def application_clear_cache(application_id):
                                     ),
                                     run_as_user=1000,
                                     run_as_group=1000,
+                                    fs_group=1000,
                                 ),
                                 volume_mounts=[
                                     kubernetes.client.V1VolumeMount(


### PR DESCRIPTION
newly minted build cache pvcs do not have a permission set. set `fsGroup` via `fs_group` to ensure that buildkit can use the volume.