### PR TITLE
give sidecar-tls containers a bit more CPU overhead

### DIFF
--- a/cabotage/celery/tasks/deploy.py
+++ b/cabotage/celery/tasks/deploy.py
@@ -511,11 +511,11 @@ def render_cabotage_sidecar_tls_container(release, unix=True, tcp=False):
         resources=kubernetes.client.V1ResourceRequirements(
             limits={
                 "memory": "128Mi",
-                "cpu": "20m",
+                "cpu": "100m",
             },
             requests={
                 "memory": "64Mi",
-                "cpu": "10m",
+                "cpu": "20m",
             },
         ),
     )


### PR DESCRIPTION
Noted that PyPI's web-api tls sidecar was seeing pretty consistent throttling at 20milicores. Set the request to 20 and leave some headroom!