### PR TITLE
attach to first web/worker pod type available

### DIFF
--- a/cabotage/server/models/projects.py
+++ b/cabotage/server/models/projects.py
@@ -256,7 +256,9 @@ class Application(db.Model, Timestamp):
 
     @property
     def latest_deployment(self):
-        return self.deployments.filter_by().order_by(Deployment.version.desc()).first()
+        return (
+            self.deployments.filter_by().order_by(Deployment.version_id.desc()).first()
+        )
 
     @property
     def latest_deployment_completed(self):


### PR DESCRIPTION
Some services may not have a verbatim `web` process. Choose first web/worker we can find.