### PR TITLE
wrap github in try except to show errors

### DIFF
--- a/cabotage/utils/github.py
+++ b/cabotage/utils/github.py
@@ -1,14 +1,27 @@
+import logging
+
 import requests
+
+logger = logging.getLogger(__name__)
 
 
 def post_deployment_status_update(access_token, status_url, state, description):
-    requests.post(
-        status_url,
-        headers={
-            "Accept": "application/vnd.github.ant-man-preview+json",
-            "Authorization": f"token {access_token}",
-            "Content-Type": "application/json",
-        },
-        json={"state": state, "description": description},
-        timeout=10,
-    )
+    if access_token is None:
+        return
+    try:
+        requests.post(
+            status_url,
+            headers={
+                "Accept": "application/vnd.github.ant-man-preview+json",
+                "Authorization": f"token {access_token}",
+                "Content-Type": "application/json",
+            },
+            json={"state": state, "description": description},
+            timeout=10,
+        )
+    except requests.exceptions.RequestException:
+        logger.exception(
+            "Failed to post deployment status update to %s (state=%s)",
+            status_url,
+            state,
+        )


### PR DESCRIPTION
<!--  Thank you for sending a pull request! Please take a moment to answer the following questions:
- Have you read our [general contributing guide](./CONTRIBUTING.md)?
- Have you added or run the appropriate tests?
- Do the commit messages and bodies explain what and why?
- If your PR is not finished, please mark it as a draft.
☝️ Please **have another look at the files changed** before opening this PR. 🙏
-->

### Description
GitHub's API is flaky a lot, and in our case i think we post to the GitHub api to add a new deployment to show status in cabo, but if we have network issues it just stays building
<img width="485" height="60" alt="image" src="https://github.com/user-attachments/assets/b5e08366-32d4-4228-983a-833e6a416e8e" />
forever.

I think we should wrap the github think and log the error , but also we do the db write during the same block so it never actually rwites if it fails.

first change:

Wrap github with try except so we catch errors like
```
[2026-02-26 14:42:39,286: ERROR/ForkPoolWorker-1] Task cabotage.celery.tasks.build.run_release_build[...] raised unexpected: ConnectTimeout(MaxRetryError("HTTPSConnectionPool(host='api.github.com', port=443): Max retries exceeded with url: /app/installations/.../access_tokens (Caused by ConnectTimeoutError(<urllib3.connection.HTTPSConnection object at 0xe86fee398850>, 'Connection to api.github.com timed out. (connect timeout=10)'))"))
```

working on the others