### PR TITLE
Websocket tidiness

### DIFF
--- a/cabotage/server/config.py
+++ b/cabotage/server/config.py
@@ -81,5 +81,6 @@ class Config(metaclass=MetaFlaskEnv):
     GITHUB_APP_PRIVATE_KEY = None
     GITHUB_WEBHOOK_SECRET = None
     SHELLZ_ENABLED = False
+    SOCK_SERVER_OPTIONS = {"ping_interval": 25}
     SIDECAR_IMAGE = "cabotage/sidecar:3"
     DATADOG_IMAGE = "datadog/agent:7.55.2"

--- a/cabotage/server/user/views.py
+++ b/cabotage/server/user/views.py
@@ -523,21 +523,24 @@ def project_application_shell_socket(ws, org_slug, project_slug, app_slug):
         _preload_content=False,
     )
 
+    last_ping = time.monotonic()
     while resp.is_open():
         resp.update()
+        now = time.monotonic()
+        if now - last_ping >= 25:
+            try:
+                resp.sock.ping()
+            except Exception:
+                break
+            last_ping = now
         if data := ws.receive(timeout=0.01):
-            print((data,))
             if data[0] == "\x00":
                 resp.write_stdin(data[1:])
             elif data[0] == "\x01":
                 resp.write_channel(kubernetes.stream.ws_client.RESIZE_CHANNEL, data[1:])
-            else:
-                print((data[0],))
         if data := resp.read_stdout(timeout=0.01):
-            print((data,))
             ws.send("\x00" + data)
         if data := resp.read_stderr(timeout=0.01):
-            print((data,))
             ws.send("\x00" + data)
 
     resp.close()


### PR DESCRIPTION
### Description

General tidiness around all our web socket handling.

- There's no need to retain a DB session while the web socket is open, this leads to transactions building up that don't go anywhere
- Add a ping interval to the sockets we control, and send pings on the socket we don't (to k8s) to keep them alive until the browser goes away.