### PR TITLE
set state of build as failed on internal error

### DIFF
--- a/cabotage/celery/tasks/build.py
+++ b/cabotage/celery/tasks/build.py
@@ -1000,6 +1000,11 @@ def run_image_build(image_id=None, buildkit=False):
                 )
             raise
     except Exception:
+        db.session.add(image)
+        if not image.error:
+            image.error = True
+            image.error_detail = "Image build failed due to an internal error"
+            db.session.commit()
         raise
 
     db.session.add(image)
@@ -1092,6 +1097,10 @@ def run_release_build(release_id=None):
                     "Release build failed.",
                 )
         except Exception:
+            release.error = True
+            release.error_detail = "Release build failed due to an internal error"
+            db.session.add(release)
+            db.session.commit()
             if (
                 "installation_id" in release.release_metadata
                 and "statuses_url" in release.release_metadata
@@ -1106,6 +1115,7 @@ def run_release_build(release_id=None):
                     "Release build failed.",
                 )
             raise
+
         db.session.add(release)
         db.session.commit()
 
@@ -1144,4 +1154,8 @@ def run_release_build(release_id=None):
                 deployment.complete = True
                 db.session.commit()
     except Exception:
+        if release is not None and not release.error:
+            release.error = True
+            release.error_detail = "Release build failed due to an internal error"
+            db.session.commit()
         raise

--- a/cabotage/celery/tasks/deploy.py
+++ b/cabotage/celery/tasks/deploy.py
@@ -1388,7 +1388,7 @@ def deploy_release(deployment):
         return False
     except Exception as exc:
         deployment.error = True
-        deployment.error_detail = f"Unexpected Error: {str(exc)}"
+        deployment.error_detail = "Deploy failed due to an internal error"
         if (
             deployment.deploy_metadata
             and "installation_id" in deployment.deploy_metadata


### PR DESCRIPTION
Rather than blind raising, set the build status as failed so that it doesn't stay "stuck" running forever.