### PR TITLE
(dev) byo github personal access token

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+/.env
 /.git
 /.ruff_cache
 /dev

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Allow overriding environment for local development
+
+# Supply a GitHub Personal Access Token to bypass API rate limits
+CABOTAGE_GITHUB_TOKEN=github_pat_...

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.env
 *.swp
 __pycache__
 .DS_Store

--- a/cabotage/celery/tasks/build.py
+++ b/cabotage/celery/tasks/build.py
@@ -526,7 +526,7 @@ def build_image_buildkit(image=None):
     buildkitd_ca = current_app.config["BUILDKITD_VERIFY"]
     buildkit_image = current_app.config["BUILDKIT_IMAGE"]
 
-    access_token = None
+    access_token = current_app.config.get("GITHUB_TOKEN")
 
     if (
         image.application.github_repository_is_private

--- a/cabotage/server/config.py
+++ b/cabotage/server/config.py
@@ -80,6 +80,7 @@ class Config(metaclass=MetaFlaskEnv):
     GITHUB_APP_ID = None
     GITHUB_APP_PRIVATE_KEY = None
     GITHUB_WEBHOOK_SECRET = None
+    GITHUB_TOKEN = None
     SHELLZ_ENABLED = False
     SOCK_SERVER_OPTIONS = {"ping_interval": 25}
     SIDECAR_IMAGE = "cabotage/sidecar:3"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,6 +134,9 @@ services:
     image: cabotage-app:docker-compose
     command: hupper -m gunicorn.app.wsgiapp -c gunicorn.conf -w 4 --threads 100 -b 0.0.0.0:8000 cabotage.server.wsgi:app
     environment: *base_environment
+    env_file:
+      - path: .env
+        required: false
     volumes:
       - .:/opt/cabotage-app/src:z
       - $HOME/.kube:/var/run/kube
@@ -148,6 +151,9 @@ services:
     image: cabotage-app:docker-compose
     command: hupper -m celery -A cabotage.celery.worker.celery_app worker --concurrency=1 --beat --scheduler redbeat.RedBeatScheduler -E --loglevel=INFO
     environment: *base_environment
+    env_file:
+      - path: .env
+        required: false
     volumes:
       - .:/opt/cabotage-app/src:z
       - $HOME/.kube:/var/run/kube


### PR DESCRIPTION
When developing locally, a middleground between a github app and no-auth is to supply a GitHub Personal Access token to bypass rate limits fetching files/repos.

This tries to allow us to do so in as safe a way as possible...