### PR TITLE
Run buildkitd via daemonless in docker compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,13 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         git build-essential libffi-dev libpq-dev
 
 COPY --from=moby/buildkit:v0.18.2-rootless /usr/bin/buildctl /usr/bin/buildctl
+COPY --from=moby/buildkit:v0.18.2-rootless /usr/bin/buildkitd /usr/bin/buildkitd
+COPY --from=moby/buildkit:v0.18.2-rootless /usr/bin/buildctl-daemonless.sh /usr/bin/buildctl-daemonless.sh
+COPY --from=moby/buildkit:v0.18.2-rootless /usr/bin/buildkit-runc /usr/bin/buildkit-runc
+COPY --from=moby/buildkit:v0.18.2-rootless /usr/bin/rootlesskit /usr/bin/rootlesskit
+COPY --from=moby/buildkit:v0.18.2-rootless /usr/bin/fuse-overlayfs /usr/bin/fuse-overlayfs
+COPY --from=moby/buildkit:v0.18.2-rootless /usr/bin/newuidmap /usr/bin/newuidmap
+COPY --from=moby/buildkit:v0.18.2-rootless /usr/bin/newgidmap /usr/bin/newgidmap
 
 ENV PYTHONUNBUFFERED 1
 

--- a/cabotage/celery/tasks/build.py
+++ b/cabotage/celery/tasks/build.py
@@ -69,8 +69,6 @@ def build_release_buildkit(release):
     registry = current_app.config["REGISTRY_BUILD"]
     registry_secure = current_app.config["REGISTRY_SECURE"]
     registry_ca = current_app.config["REGISTRY_VERIFY"]
-    buildkitd_url = current_app.config["BUILDKITD_URL"]
-    buildkitd_ca = current_app.config["BUILDKITD_VERIFY"]
     buildkit_image = current_app.config["BUILDKIT_IMAGE"]
 
     process_commands = "\n".join(
@@ -355,9 +353,7 @@ def build_release_buildkit(release):
                 "context=context",
             ]
             context_configmap_object = release.release_build_context_configmap
-            buildctl_command = ["buildctl"]
-            if buildkitd_ca is not None:
-                buildctl_args.insert(0, f"--tlscacert={buildkitd_ca}")
+            buildctl_command = ["buildctl-daemonless.sh"]
             with TemporaryDirectory() as tempdir:
                 os.makedirs(os.path.join(tempdir, "context"), exist_ok=True)
                 for file, contents in context_configmap_object.data.items():
@@ -366,11 +362,21 @@ def build_release_buildkit(release):
                 os.makedirs(os.path.join(tempdir, ".docker"), exist_ok=True)
                 with open(os.path.join(tempdir, ".docker", "config.json"), "w") as f:
                     f.write(dockerconfigjson)
+                with open(os.path.join(tempdir, "buildkitd.toml"), "w") as f:
+                    f.write(buildkitd_toml)
 
                 try:
                     output = run_and_stream(
                         buildctl_command + buildctl_args,
-                        env={"BUILDKIT_HOST": buildkitd_url, "HOME": tempdir},
+                        env={
+                            **os.environ,
+                            "BUILDKITD_FLAGS": (
+                                f"--root=/tmp/buildkit-{release.application.id}"
+                                f" --config={tempdir}/buildkitd.toml"
+                                " --oci-worker=true --oci-worker-binary=/usr/bin/buildkit-runc"
+                            ),
+                            "HOME": tempdir,
+                        },
                         cwd=tempdir,
                         broker_url=current_app.config["CELERY_BROKER_URL"],
                         build_type="release",
@@ -522,8 +528,6 @@ def build_image_buildkit(image=None):
     registry = current_app.config["REGISTRY_BUILD"]
     registry_secure = current_app.config["REGISTRY_SECURE"]
     registry_ca = current_app.config["REGISTRY_VERIFY"]
-    buildkitd_url = current_app.config["BUILDKITD_URL"]
-    buildkitd_ca = current_app.config["BUILDKITD_VERIFY"]
     buildkit_image = current_app.config["BUILDKIT_IMAGE"]
 
     access_token = current_app.config.get("GITHUB_TOKEN")
@@ -919,9 +923,7 @@ def build_image_buildkit(image=None):
             if not job_complete:
                 raise BuildError("Image build failed!")
         else:
-            buildctl_command = ["buildctl"]
-            if buildkitd_ca is not None:
-                buildctl_args.insert(0, f"--tlscacert={buildkitd_ca}")
+            buildctl_command = ["buildctl-daemonless.sh"]
             if image.application.github_repository_is_private:
                 buildctl_args.append("--secret")
                 buildctl_args.append(
@@ -940,11 +942,21 @@ def build_image_buildkit(image=None):
                         os.path.join(tempdir, ".secret", "github_access_token"), "w"
                     ) as f:
                         f.write(access_token)
+                with open(os.path.join(tempdir, "buildkitd.toml"), "w") as f:
+                    f.write(buildkitd_toml)
 
                 try:
                     output = run_and_stream(
                         buildctl_command + buildctl_args,
-                        env={"BUILDKIT_HOST": buildkitd_url, "HOME": tempdir},
+                        env={
+                            **os.environ,
+                            "BUILDKITD_FLAGS": (
+                                f"--root=/tmp/buildkit-{image.application.id}"
+                                f" --config={tempdir}/buildkitd.toml"
+                                " --oci-worker=true --oci-worker-binary=/usr/bin/buildkit-runc"
+                            ),
+                            "HOME": tempdir,
+                        },
                         cwd=tempdir,
                         broker_url=current_app.config["CELERY_BROKER_URL"],
                         build_type="image",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -154,6 +154,8 @@ services:
     env_file:
       - path: .env
         required: false
+    # worker runs buildkitd-daemonless directly to simulate cache isolation locally
+    privileged: true
     volumes:
       - .:/opt/cabotage-app/src:z
       - $HOME/.kube:/var/run/kube


### PR DESCRIPTION
This simulates isolated build caches like we have in production.

Without this it is impossible to have multiple applications building the same repo without getting cross-repo blob collisions.