### PR TITLE
avoid processing deployments from other github apps

### DIFF
--- a/cabotage/celery/tasks/github.py
+++ b/cabotage/celery/tasks/github.py
@@ -117,6 +117,15 @@ def _resolve_app_env_for_hook(installation_id, repository_name, environment):
 def process_deployment_hook(hook):
     installation_id = hook.payload["installation"]["id"]
     deployment = hook.payload["deployment"]
+
+    # Only process deployments created by this app's bot
+    if deployment["creator"]["login"] != github_app.bot_login:
+        print(
+            f"ignoring deployment created by {deployment['creator']['login']} "
+            f"(not {github_app.bot_login})"
+        )
+        return False
+
     environment = deployment["environment"]
     repository_name = hook.payload["repository"]["full_name"]
     commit_sha = hook.payload["deployment"]["sha"]

--- a/cabotage/server/ext/github_app.py
+++ b/cabotage/server/ext/github_app.py
@@ -21,6 +21,7 @@ class GitHubApp(object):
         self.app_private_key_pem = None
         self._bearer_token = None
         self._bearer_token_exp = -1
+        self._bot_login = None
 
         if app.config["GITHUB_WEBHOOK_SECRET"]:
             self.webhook_secret = app.config["GITHUB_WEBHOOK_SECRET"]
@@ -64,6 +65,21 @@ class GitHubApp(object):
             )
             self._bearer_token_exp = issued + 599
         return self._bearer_token
+
+    @property
+    def bot_login(self):
+        if self._bot_login is None:
+            resp = requests.get(
+                "https://api.github.com/app",
+                headers={
+                    "Accept": "application/vnd.github+json",
+                    "Authorization": f"Bearer {self.bearer_token}",
+                },
+                timeout=10,
+            )
+            resp.raise_for_status()
+            self._bot_login = f"{resp.json()['slug']}[bot]"
+        return self._bot_login
 
     def fetch_installation_access_token(self, installation_id):
         access_token_response = requests.post(


### PR DESCRIPTION
Currently we _only_ filter deployment web hooks we get based on the environment name. This means that if the same effective environment exists on multiple clusters, we will deploy multiple times.

Each cluster should filter for deployments it created.