### PR TITLE
Add tooltips and info modal for disabled tabs

### DIFF
--- a/cabotage/client/static/main.css
+++ b/cabotage/client/static/main.css
@@ -337,8 +337,137 @@ html:not([data-theme-pref]) .theme-icon-system {
 }
 .tab-item.tab-disabled {
   opacity: 0.4;
-  cursor: default;
+  cursor: not-allowed;
+  pointer-events: auto;
+}
+.tab-item.tab-disabled:hover {
+  background: transparent;
+  color: inherit;
+  border-bottom-color: transparent;
+}
+
+/* Floating tooltip card for disabled tabs */
+.tab-tip {
+  position: fixed;
+  z-index: 200;
+  width: 18rem;
+  background: var(--color-base-200, oklch(0.2 0 0));
+  border: 1px solid var(--color-base-300, oklch(0.3 0 0));
+  border-radius: 0.5rem;
+  box-shadow:
+    0 4px 24px rgba(0, 0, 0, 0.4),
+    0 0 0 1px rgba(255, 255, 255, 0.03);
   pointer-events: none;
+  opacity: 0;
+  transform: translateY(-4px);
+  transition:
+    opacity 0.2s cubic-bezier(0.4, 0, 0.2, 1),
+    transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  overflow: hidden;
+  white-space: normal;
+}
+.tab-tip.tab-tip-visible {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+.tab-tip::before {
+  content: '';
+  position: absolute;
+  top: -5px;
+  left: 1.25rem;
+  transform: rotate(45deg);
+  width: 10px;
+  height: 10px;
+  background: var(--color-base-200, oklch(0.2 0 0));
+  border-left: 1px solid var(--color-base-300, oklch(0.3 0 0));
+  border-top: 1px solid var(--color-base-300, oklch(0.3 0 0));
+}
+.tab-tip-header {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.5rem 0.75rem;
+  background: var(--color-base-300, oklch(0.18 0 0 / 0.5));
+  border-bottom: 1px solid color-mix(in oklch, var(--color-base-content) 8%, transparent);
+}
+.tab-tip-header-icon {
+  width: 0.875rem;
+  height: 0.875rem;
+  color: var(--color-primary, oklch(0.55 0.24 285));
+  opacity: 0.7;
+  flex-shrink: 0;
+}
+.tab-tip-header-text {
+  font-size: 0.625rem;
+  font-weight: 600;
+  color: var(--color-base-content, oklch(0.55 0 0));
+  opacity: 0.5;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.tab-tip-body {
+  padding: 0.625rem 0.75rem;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  color: var(--color-base-content, oklch(0.9 0 0));
+}
+.tab-tip-body p {
+  margin: 0;
+  opacity: 0.7;
+}
+.tab-tip-body code {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  padding: 0.125rem 0.375rem;
+  background: color-mix(in oklch, var(--color-base-content) 8%, transparent);
+  border-radius: 0.25rem;
+  color: var(--accent-text, var(--color-primary));
+}
+.tab-tip-footer {
+  padding: 0.5rem 0.75rem;
+  border-top: 1px solid color-mix(in oklch, var(--color-base-content) 8%, transparent);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.tab-tip-footer-hint {
+  font-size: 0.6875rem;
+  color: var(--accent-text, var(--color-primary));
+  opacity: 0.6;
+  cursor: pointer;
+  transition: opacity 0.15s ease;
+}
+.tab-tip-footer-hint:hover {
+  opacity: 1;
+}
+
+/* Disabled tab info modal — reuses raw-editor-modal/raw-editor-dialog shell */
+.tab-info-modal-icon {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 0.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  background: color-mix(in oklch, var(--color-primary) 12%, transparent);
+  color: var(--color-primary, oklch(0.55 0.24 285));
+}
+.tab-info-modal-text {
+  font-size: 0.875rem;
+  line-height: 1.6;
+  color: var(--color-base-content);
+  opacity: 0.6;
+  margin-bottom: 1.25rem;
+}
+.tab-info-modal-text code {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8125rem;
+  padding: 0.125rem 0.375rem;
+  background: color-mix(in oklch, var(--color-base-content) 8%, transparent);
+  border-radius: 0.25rem;
+  color: var(--accent-text, var(--color-primary));
 }
 
 @media (max-width: 639px) {

--- a/cabotage/client/static/main.js
+++ b/cabotage/client/static/main.js
@@ -2084,6 +2084,134 @@ function initPreferenceToggles() {
   });
 }
 
+/* Disabled Tab Tips — hover tooltip card + click info modal */
+function initTabTips() {
+  var tipEl = document.createElement('div');
+  tipEl.className = 'tab-tip';
+  tipEl.innerHTML =
+    '<div class="tab-tip-header">' +
+      '<svg class="tab-tip-header-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' +
+        '<circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/>' +
+      '</svg>' +
+      '<span class="tab-tip-header-text">Not Available</span>' +
+    '</div>' +
+    '<div class="tab-tip-body"><p></p></div>' +
+    '<div class="tab-tip-footer"><span class="tab-tip-footer-hint js-tab-tip-detail">Click for details</span></div>';
+  document.body.appendChild(tipEl);
+
+  var currentTipSource = null;
+
+  var tipBody = tipEl.querySelector('.tab-tip-body p');
+  var hideTimer = null;
+
+  function formatMsg(raw) {
+    // Escape HTML, then convert `backtick` spans to <code>
+    var safe = raw.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    return safe.replace(/`([^`]+)`/g, '<code>$1</code>');
+  }
+
+  function show(el) {
+    clearTimeout(hideTimer);
+    var msg = el.getAttribute('data-tab-tip');
+    if (!msg) return;
+    currentTipSource = el;
+    tipBody.innerHTML = formatMsg(msg);
+    tipEl.classList.add('tab-tip-visible');
+
+    var rect = el.getBoundingClientRect();
+    var tipRect = tipEl.getBoundingClientRect();
+    var left = rect.left + (rect.width / 2) - (tipRect.width / 2);
+    // Clamp to viewport
+    left = Math.max(8, Math.min(left, window.innerWidth - tipRect.width - 8));
+    tipEl.style.top = (rect.bottom + 8) + 'px';
+    tipEl.style.left = left + 'px';
+  }
+  function cancelHide() {
+    clearTimeout(hideTimer);
+  }
+  function hide() {
+    hideTimer = setTimeout(function () {
+      tipEl.classList.remove('tab-tip-visible');
+    }, 200);
+  }
+
+  // Allow hovering the tooltip itself without it disappearing
+  tipEl.addEventListener('mouseenter', cancelHide);
+  tipEl.addEventListener('mouseleave', hide);
+
+  // "Click for details" in the tooltip footer opens the modal
+  tipEl.querySelector('.js-tab-tip-detail').addEventListener('click', function () {
+    tipEl.classList.remove('tab-tip-visible');
+    if (currentTipSource) openTabInfoModal(currentTipSource);
+  });
+
+  document.querySelectorAll('[data-tab-tip]').forEach(function (el) {
+    el.addEventListener('mouseenter', function () { show(el); });
+    el.addEventListener('mouseleave', hide);
+    el.addEventListener('click', function (e) {
+      e.preventDefault();
+      e.stopPropagation();
+      tipEl.classList.remove('tab-tip-visible');
+      openTabInfoModal(el);
+    });
+  });
+
+  // Info modal
+  var modal = document.getElementById('tab-info-modal');
+  if (!modal) return;
+
+  var titleEl = modal.querySelector('.tab-info-modal-title');
+  var textEl = modal.querySelector('.tab-info-modal-text');
+  var actionsEl = modal.querySelector('.tab-info-modal-actions');
+
+  function closeModal() { modal.style.display = 'none'; }
+
+  modal.querySelectorAll('[data-tab-info-close]').forEach(function (el) {
+    el.addEventListener('click', closeModal);
+  });
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape' && modal.style.display !== 'none') closeModal();
+  });
+
+  function openTabInfoModal(el) {
+    var label = el.textContent.replace(/\(Soon\)/i, '').trim();
+    var msg = el.getAttribute('data-tab-tip') || '';
+    var isPipeline = label.toLowerCase() === 'pipeline';
+
+    titleEl.textContent = label + ' is not available';
+    textEl.innerHTML = formatMsg(msg);
+    actionsEl.innerHTML = '';
+
+    if (!isPipeline) {
+      var goBtn = document.createElement('a');
+      goBtn.href = '#config';
+      goBtn.className = 'btn btn-primary btn-sm';
+      goBtn.textContent = 'Go to Config';
+      goBtn.addEventListener('click', function (e) {
+        e.preventDefault();
+        closeModal();
+        // Activate config tab if it exists, or scroll to #config
+        var configTab = document.querySelector('[data-tab="config"]');
+        if (configTab) {
+          configTab.click();
+        } else {
+          window.location.hash = 'config';
+        }
+      });
+      actionsEl.appendChild(goBtn);
+    }
+
+    var dismissBtn = document.createElement('button');
+    dismissBtn.type = 'button';
+    dismissBtn.className = isPipeline ? 'btn btn-primary btn-sm' : 'btn btn-ghost btn-sm';
+    dismissBtn.textContent = 'Got it';
+    dismissBtn.addEventListener('click', closeModal);
+    actionsEl.appendChild(dismissBtn);
+
+    modal.style.display = 'flex';
+  }
+}
+
 document.addEventListener('click', function (e) {
   var el = e.target.closest('[data-href]');
   if (el) {
@@ -2113,6 +2241,7 @@ document.addEventListener('DOMContentLoaded', function () {
   syncDetailLogHeight();
   initAnnotationTables();
   initIngressForms();
+  initTabTips();
   window.addEventListener('resize', function () {
     autoExpandCollapsibleCards();
     syncDetailLogHeight();

--- a/cabotage/client/templates/_base.html
+++ b/cabotage/client/templates/_base.html
@@ -661,6 +661,30 @@
     {% endif %}
     {% block js %}
     {% endblock js %}
+    <div id="tab-info-modal" class="raw-editor-modal" style="display:none;">
+      <div class="raw-editor-backdrop" data-tab-info-close></div>
+      <div class="raw-editor-dialog" style="max-width: 28rem;">
+        <div class="flex items-center justify-between mb-5">
+          <div class="flex items-center gap-2.5">
+            <div class="tab-info-modal-icon">
+              <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/>
+              </svg>
+            </div>
+            <h3 class="tab-info-modal-title text-base font-semibold text-base-content"></h3>
+          </div>
+          <button type="button"
+                  data-tab-info-close
+                  class="btn btn-ghost btn-sm btn-circle">
+            <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+            </svg>
+          </button>
+        </div>
+        <p class="tab-info-modal-text"></p>
+        <div class="tab-info-modal-actions flex gap-2"></div>
+      </div>
+    </div>
     <div id="expand-modal" class="raw-editor-modal hidden">
       <div class="raw-editor-backdrop"></div>
       <div class="raw-editor-dialog"

--- a/cabotage/client/templates/_macros.html
+++ b/cabotage/client/templates/_macros.html
@@ -56,7 +56,8 @@
   <div class="tab-bar {{ tab_bar_class }}" data-tabs>
     {% for tab in tabs %}
       {% if tab.disabled is defined and tab.disabled %}
-        <span class="tab-item tab-disabled">
+        <span class="tab-item tab-disabled"
+              {% if tab.tooltip is defined and tab.tooltip %}data-tab-tip="{{ tab.tooltip }}"{% endif %}>
           {% if tab.icon %}{{ icon(tab.icon, 'w-4 h-4') }}{% endif %}
           {{ tab.label }}
         </span>
@@ -98,14 +99,14 @@
          class="tab-item
                 {% if active == 'observe' %}tab-active{% endif %}">{{ icon('bar-chart', 'w-4 h-4') }} Observe</a>
       {% else %}
-      <span class="tab-item tab-disabled">{{ icon('bar-chart', 'w-4 h-4') }} Observe</span>
+      <span class="tab-item tab-disabled" data-tab-tip="Observability requires `MIMIR_URL` to be configured by a Cabotage platform administrator.">{{ icon('bar-chart', 'w-4 h-4') }} Observe</span>
       {% endif %}
       {% if config.LOKI_URL %}
       <a href="{{ url_for('user.project_application_logs_view', org_slug=org_slug, project_slug=project_slug, app_slug=app_slug, env_slug=env_slug) }}"
          class="tab-item
                 {% if active == 'logs' %}tab-active{% endif %}">{{ icon('file-text', 'w-4 h-4') }} Logs</a>
       {% else %}
-      <span class="tab-item tab-disabled">{{ icon('file-text', 'w-4 h-4') }} Logs</span>
+      <span class="tab-item tab-disabled" data-tab-tip="Log viewing requires `LOKI_URL` to be configured by a Cabotage platform administrator.">{{ icon('file-text', 'w-4 h-4') }} Logs</span>
       {% endif %}
       <a href="{{ overview_url }}#config"
          class="tab-item
@@ -126,7 +127,7 @@
       <a href="{{ url_for('user.application_releases', org_slug=org_slug, project_slug=project_slug, app_slug=app_slug, env_slug=env_slug) }}"
          class="tab-item
                 {% if active == 'releases' %}tab-active{% endif %}">{{ icon('layers', 'w-4 h-4') }} Releases</a>
-      <span class="tab-item tab-disabled">{{ icon('bar-chart-2', 'w-4 h-4') }} Pipeline <span class="text-[0.6rem] opacity-50">(Soon)</span></span>
+      <span class="tab-item tab-disabled" data-tab-tip="Pipeline is coming soon and is not yet available.">{{ icon('bar-chart-2', 'w-4 h-4') }} Pipeline <span class="text-[0.6rem] opacity-50">(Soon)</span></span>
       {% if config.INGRESS_DOMAIN %}
       <a href="{{ url_for('user.project_application_ingress', org_slug=org_slug, project_slug=project_slug, app_slug=app_slug, env_slug=env_slug) }}"
          class="tab-item

--- a/cabotage/client/templates/user/project_application.html
+++ b/cabotage/client/templates/user/project_application.html
@@ -55,12 +55,12 @@
   <div class="app-content-padded !py-0">
     {{ tab_nav([
         {'id': 'overview', 'label': 'Overview', 'icon': 'activity'},
-        {'id': 'observe', 'label': 'Observe', 'icon': 'bar-chart', 'disabled': not config.MIMIR_URL, 'url': url_for('user.project_application_observe', org_slug=org_slug, project_slug=project_slug, app_slug=app_slug, env_slug=environment.slug if environment else none) if config.MIMIR_URL else none},
+        {'id': 'observe', 'label': 'Observe', 'icon': 'bar-chart', 'disabled': not config.MIMIR_URL, 'tooltip': 'Observability requires `MIMIR_URL` to be configured by a Cabotage platform administrator.', 'url': url_for('user.project_application_observe', org_slug=org_slug, project_slug=project_slug, app_slug=app_slug, env_slug=environment.slug if environment else none) if config.MIMIR_URL else none},
         {'id': 'config', 'label': 'Config', 'icon': 'key', 'badge': app_env.configurations|rejectattr('name', 'equalto', 'CABOTAGE_SENTINEL') |list|length},
     {'id': 'images', 'label': 'Images', 'icon': 'image'},
     {'id': 'releases', 'label': 'Releases', 'icon': 'layers'},
     {'id': 'deployments', 'label': 'Deploys', 'icon': 'deploy'},
-    {'id': 'pipeline', 'label': 'Pipeline (Soon)', 'icon': 'bar-chart-2', 'disabled': true}
+    {'id': 'pipeline', 'label': 'Pipeline (Soon)', 'icon': 'bar-chart-2', 'disabled': true, 'tooltip': 'Pipeline is coming soon and is not yet available.'}
     ]) }}
   </div>
   {% endif %}


### PR DESCRIPTION
<!--  Thank you for sending a pull request! Please take a moment to answer the following questions:
- Have you read our [general contributing guide](./CONTRIBUTING.md)?
- Have you added or run the appropriate tests?
- Do the commit messages and bodies explain what and why?
- If your PR is not finished, please mark it as a draft.
☝️ Please **have another look at the files changed** before opening this PR. 🙏
-->

### Description
In locaal dev therese items arent auto enabled sometimes, or witha. new cabo deploy on a new cluster they may be forgotten to set the correct platofrm config vars.

Disabled tabs (Observe, Logs, Pipeline) now show a rich card-style tooltip on hover explaining why they're unavailable, with a click-through info modal matching the existing raw-editor-modal pattern. Env var names render as inline code pills. Tooltip is hoverable with a delayed hide.

<img width="410" height="240" alt="image" src="https://github.com/user-attachments/assets/c2766674-1b58-4183-b3e2-deef6b97aa57" />

similarly the Pipeline tab just says `not yet available`
