### PR TITLE
allow deep-linking to the logviewer page with a process name

### DIFF
--- a/cabotage/client/static/main.js
+++ b/cabotage/client/static/main.js
@@ -1943,7 +1943,13 @@ function initLokiLogViewer() {
     function stopPolling() { if (pollTimer) { clearTimeout(pollTimer); pollTimer = null; } }
     function resetAndPoll() { stopPolling(); cancelFetch(); fetchLogs('reset'); }
 
-    processFilter.addEventListener('change', function() { resetAndPoll(); });
+    processFilter.addEventListener('change', function() {
+      var url = new URL(window.location);
+      if (processFilter.value) { url.searchParams.set('process', processFilter.value); }
+      else { url.searchParams.delete('process'); }
+      history.replaceState(null, '', url);
+      resetAndPoll();
+    });
     searchInput.addEventListener('input', function() {
       clearTimeout(debounceTimer);
       debounceTimer = setTimeout(function() { resetAndPoll(); }, 300);

--- a/cabotage/client/templates/_macros.html
+++ b/cabotage/client/templates/_macros.html
@@ -926,7 +926,7 @@
   {% endif %}
 {% endmacro %}
 
-{% macro loki_log_viewer(query_url, process_names=[], loki_configured=true, no_poll=false) %}
+{% macro loki_log_viewer(query_url, process_names=[], loki_configured=true, no_poll=false, active_process='') %}
   {% if not loki_configured %}
     <div class="alert alert-warning">
       {{ icon('alert-triangle', 'w-4 h-4') }}
@@ -940,9 +940,9 @@
       {# Controls bar #}
       <div class="flex items-center gap-3 mb-4 flex-wrap">
         <select class="js-process-filter select select-bordered select-sm bg-base-100 text-base-content border-base-content/10">
-          <option value="">All processes</option>
+          <option value="" {{ 'selected' if not active_process }}>All processes</option>
           {% for proc in process_names %}
-            <option value="{{ proc }}">{{ proc }}</option>
+            <option value="{{ proc }}" {{ 'selected' if proc == active_process }}>{{ proc }}</option>
           {% endfor %}
         </select>
 

--- a/cabotage/client/templates/user/project_application_logs_view.html
+++ b/cabotage/client/templates/user/project_application_logs_view.html
@@ -40,6 +40,7 @@
         query_url=url_for('user.project_application_logs_query', org_slug=org_slug, project_slug=project_slug, app_slug=app_slug, env_slug=env_slug),
         process_names=process_names,
         loki_configured=loki_configured,
+        active_process=request.args.get('process', ''),
     ) }}
   </div>
 {% endblock content %}


### PR DESCRIPTION
makes the lil pillz on the application detail page useful

follow on from #229 