### PR TITLE
allow Image builds to reference SOURCE_COMMIT

### DIFF
--- a/cabotage/celery/tasks/build.py
+++ b/cabotage/celery/tasks/build.py
@@ -754,6 +754,9 @@ def build_image_buildkit(image=None):
         ),
     ]
 
+    buildctl_args.append("--opt")
+    buildctl_args.append(shlex.quote(f"build-arg:SOURCE_COMMIT={image.commit_sha}"))
+
     for k, v in image.buildargs(config_writer).items():
         buildctl_args.append("--opt")
         buildctl_args.append(shlex.quote(f"build-arg:{k}={v}"))


### PR DESCRIPTION
Allows users to embed commit sha's and such in their builds.