### PR TITLE
fix memory queries so they don't report 2x usage :)

### DIFF
--- a/cabotage/client/templates/user/project_application_observe.html
+++ b/cabotage/client/templates/user/project_application_observe.html
@@ -28,6 +28,10 @@
       {% set base_url = url_for('user.project_application_observe', org_slug=org_slug, project_slug=project_slug, app_slug=app_slug, env_slug=env_slug) %}
       <div class="flex flex-col items-end gap-1">
         <div class="flex items-center gap-2">
+          <label class="flex items-center gap-1.5 text-xs text-base-content/40 cursor-pointer select-none" title="Include envconsul and sidecar containers in resource metrics">
+            <input type="checkbox" id="system-containers-toggle" class="checkbox checkbox-xs">
+            <span>System</span>
+          </label>
           {% if process_names|length > 1 %}
             <select id="process-filter" class="select select-sm select-bordered text-xs">
               <option value="">All processes</option>
@@ -628,8 +632,11 @@
 
     var processEl = document.getElementById('process-filter');
     var proc = processEl ? processEl.value : '';
+    var sysToggle = document.getElementById('system-containers-toggle');
+    var includeSys = sysToggle && sysToggle.checked;
     var qs = '?metric=' + metric + '&range=' + RANGE + '&group=' + group;
     if (proc) qs += '&process=' + encodeURIComponent(proc);
+    if (includeSys) qs += '&system_containers=1';
     if (windowStart && windowEnd) {
       qs += '&start=' + windowStart + '&end=' + windowEnd;
     }
@@ -702,6 +709,17 @@
   if (processEl) {
     processEl.addEventListener('change', function() {
       updateURL();
+      document.querySelectorAll('[data-metric-panel]').forEach(function(el) {
+        el.innerHTML = '<div class="flex items-center justify-center h-full text-base-content/20"><span class="loading loading-spinner loading-sm"></span></div>';
+      });
+      Object.keys(panels).forEach(fetchAndRender);
+    });
+  }
+
+  // System containers toggle
+  var sysToggleEl = document.getElementById('system-containers-toggle');
+  if (sysToggleEl) {
+    sysToggleEl.addEventListener('change', function() {
       document.querySelectorAll('[data-metric-panel]').forEach(function(el) {
         el.innerHTML = '<div class="flex items-center justify-center h-full text-base-content/20"><span class="loading loading-spinner loading-sm"></span></div>';
       });

--- a/cabotage/server/user/views.py
+++ b/cabotage/server/user/views.py
@@ -4542,11 +4542,23 @@ def project_application_observe_metric(org_slug, project_slug, app_slug, env_slu
 
     # Optional process filter
     process_filter = request.args.get("process", "")
+    include_system = request.args.get("system_containers", "") == "1"
+    # Exclude pod-level aggregates and pause container; optionally exclude
+    # sidecar containers when system_containers is off.
+    container_filter = 'container!="", container!="POD"'
+    if not include_system:
+        container_filter += (
+            ', container!="cabotage-sidecar"'
+            ', container!="cabotage-sidecar-tls"'
+            ', container!="cabotage-enroller"'
+        )
     if process_filter:
         escaped_process = _REGEX_META.sub(r"\\\g<0>", process_filter)
-        labels = f'namespace="{namespace}", pod=~"{escaped_prefix}-{escaped_process}-[a-z0-9]+-[a-z0-9]+"'
+        labels = f'namespace="{namespace}", pod=~"{escaped_prefix}-{escaped_process}-[a-z0-9]+-[a-z0-9]+", {container_filter}'
     else:
-        labels = f'namespace="{namespace}", pod=~"{escaped_prefix}-.*"'
+        labels = (
+            f'namespace="{namespace}", pod=~"{escaped_prefix}-.*", {container_filter}'
+        )
 
     # Build exact traefik service labels from ingress config.
     # nginx-ingress format: {ns}-{prefix}-{ingress.name}-{prefix}-{process}-{port}@kubernetesingressnginx
@@ -4858,9 +4870,15 @@ def project_application_live_stats(org_slug, project_slug, app_slug, env_slug=No
     cpu_history = []
     mem_history = []
 
+    app_labels = (
+        f'namespace="{namespace}", pod=~"{escaped_prefix}-.*"'
+        ', container!="", container!="POD"'
+        ', container!="cabotage-sidecar"'
+        ', container!="cabotage-sidecar-tls"'
+        ', container!="cabotage-enroller"'
+    )
     cpu_series = _query_mimir_range(
-        f"sum(rate(container_cpu_usage_seconds_total"
-        f'{{namespace="{namespace}", pod=~"{escaped_prefix}-.*"}}[{step}s]))',
+        f"sum(rate(container_cpu_usage_seconds_total" f"{{{app_labels}}}[{step}s]))",
         start,
         end,
         step,
@@ -4870,8 +4888,7 @@ def project_application_live_stats(org_slug, project_slug, app_slug, env_slug=No
             cpu_history.append([ts, round(float(val) * 1000, 1)])
 
     mem_series = _query_mimir_range(
-        f"sum(container_memory_working_set_bytes"
-        f'{{namespace="{namespace}", pod=~"{escaped_prefix}-.*"}})',
+        f"sum(container_memory_working_set_bytes" f"{{{app_labels}}})",
         start,
         end,
         step,
@@ -4888,16 +4905,22 @@ def project_application_live_stats(org_slug, project_slug, app_slug, env_slug=No
         pod_regex = "|".join(
             _REGEX_META.sub(r"\\\g<0>", name) for name in running_pod_names
         )
+        app_container_filter = (
+            ', container!="", container!="POD"'
+            ', container!="cabotage-sidecar"'
+            ', container!="cabotage-sidecar-tls"'
+            ', container!="cabotage-enroller"'
+        )
         cpu_result = _query_mimir_instant(
             f"sum(rate(container_cpu_usage_seconds_total"
-            f'{{namespace="{namespace}", pod=~"{pod_regex}"}}[5m]))'
+            f'{{namespace="{namespace}", pod=~"{pod_regex}"{app_container_filter}}}[5m]))'
         )
         if cpu_result and len(cpu_result) > 0 and cpu_result[0].get("value"):
             cpu_val = round(float(cpu_result[0]["value"][1]) * 1000, 1)
 
         mem_result = _query_mimir_instant(
             f"sum(container_memory_working_set_bytes"
-            f'{{namespace="{namespace}", pod=~"{pod_regex}"}})'
+            f'{{namespace="{namespace}", pod=~"{pod_regex}"{app_container_filter}}})'
         )
         if mem_result and len(mem_result) > 0 and mem_result[0].get("value"):
             mem_val = float(mem_result[0]["value"][1])


### PR DESCRIPTION
The memory queries previously double-counted due to series being reported for pod level and container level metrics. add filters, and exclude cabotage side cars, allow users to include system memory usage as well for review.