### PR TITLE
log deploy errors instead of silently failing

### DIFF
--- a/cabotage/celery/tasks/github.py
+++ b/cabotage/celery/tasks/github.py
@@ -351,6 +351,11 @@ def create_deployment(
             "Deployment created.",
         )
     except Exception:
+        logger.exception(
+            "failed to create deployment for %s ref=%s",
+            repository_name,
+            ref,
+        )
         return None
     return statuses_url
 


### PR DESCRIPTION
## Description
If a deploy fails we won't really know why because the exception is just swallowed