### PR TITLE
fix: import icon macro in base template to prevent 500 on pages missng the import

### DIFF
--- a/cabotage/client/templates/_base.html
+++ b/cabotage/client/templates/_base.html
@@ -1,3 +1,4 @@
+{% from "_macros.html" import icon %}
 <!DOCTYPE html>
 <html lang="en">
   <head>


### PR DESCRIPTION
Some users get a 500 when trying to make a project or app if they aren't linked with GitHub (or are only linked with GitHub?)