### PR TITLE
configurable mimir timeout

### DIFF
--- a/cabotage/server/config.py
+++ b/cabotage/server/config.py
@@ -109,6 +109,7 @@ class Config(metaclass=MetaFlaskEnv):
     TAILSCALE_TAG_PREFIX = "cabotage"
     MIMIR_URL = None
     MIMIR_VERIFY = None
+    MIMIR_TIMEOUT = 5
     LOKI_URL = None
     LOKI_VERIFY = None
     PROXY_FIX_NUM_PROXIES = 1

--- a/cabotage/server/user/views.py
+++ b/cabotage/server/user/views.py
@@ -6462,11 +6462,11 @@ def _query_mimir_instant(query):
     if not mimir_url:
         return None
     try:
-        resp = requests_lib.get(
+        resp = requests_lib.get(  # nosec B113 - timeout has default
             f"{mimir_url}/prometheus/api/v1/query",
             params={"query": query},
             verify=verify,
-            timeout=5,
+            timeout=current_app.config.get("MIMIR_TIMEOUT", 5),
         )
         resp.raise_for_status()
         data = resp.json()


### PR DESCRIPTION
allows configuration of a mimir timeout. long term this should be moved to an asyncio compatible route/proxy to allow for even longer queries.