### PR TITLE
correctly cleanup buildcaches from branch deploys

### DIFF
--- a/cabotage/celery/tasks/branch_deploy.py
+++ b/cabotage/celery/tasks/branch_deploy.py
@@ -302,7 +302,11 @@ def _teardown_environment(environment):
     """Delete k8s namespace and all DB records for an ephemeral environment."""
     import kubernetes
 
-    from cabotage.celery.tasks.build import build_cache_pvc_name
+    from cabotage.celery.tasks.build import (
+        _build_namespace,
+        build_cache_pvc_labels,
+        build_cache_pvc_name,
+    )
     from cabotage.celery.tasks.resources import (
         _RECONCILERS,
         _acquire_reconcile_lock,
@@ -382,16 +386,65 @@ def _teardown_environment(environment):
 
             # Clean up build cache PVCs
             for app_env in environment.active_application_environments:
+                build_namespace = _build_namespace(app_env)
                 pvc_name = build_cache_pvc_name(app_env)
+                deleted_cache_pvcs = set()
+                selector = ",".join(
+                    f"{key}={value}"
+                    for key, value in sorted(build_cache_pvc_labels(app_env).items())
+                )
                 try:
-                    core_api.delete_namespaced_persistent_volume_claim(
-                        pvc_name, "default", propagation_policy="Foreground"
+                    pvcs = core_api.list_namespaced_persistent_volume_claim(
+                        build_namespace,
+                        label_selector=selector,
                     )
-                    logger.info("Deleted build cache PVC %s", pvc_name)
+                    for pvc in pvcs.items:
+                        try:
+                            core_api.delete_namespaced_persistent_volume_claim(
+                                pvc.metadata.name,
+                                build_namespace,
+                                propagation_policy="Foreground",
+                            )
+                            deleted_cache_pvcs.add(pvc.metadata.name)
+                            logger.info(
+                                "Deleted build cache PVC %s/%s",
+                                build_namespace,
+                                pvc.metadata.name,
+                            )
+                        except ApiException as exc:
+                            if exc.status != 404:
+                                logger.warning(
+                                    "Failed to delete build cache PVC %s/%s: %s",
+                                    build_namespace,
+                                    pvc.metadata.name,
+                                    exc,
+                                )
                 except ApiException as exc:
                     if exc.status != 404:
                         logger.warning(
-                            "Failed to delete build cache PVC %s: %s",
+                            "Failed to list build cache PVCs in %s with %s: %s",
+                            build_namespace,
+                            selector,
+                            exc,
+                        )
+
+                if pvc_name in deleted_cache_pvcs:
+                    continue
+
+                try:
+                    core_api.delete_namespaced_persistent_volume_claim(
+                        pvc_name,
+                        build_namespace,
+                        propagation_policy="Foreground",
+                    )
+                    logger.info(
+                        "Deleted build cache PVC %s/%s", build_namespace, pvc_name
+                    )
+                except ApiException as exc:
+                    if exc.status != 404:
+                        logger.warning(
+                            "Failed to delete build cache PVC %s/%s: %s",
+                            build_namespace,
                             pvc_name,
                             exc,
                         )

--- a/cabotage/celery/tasks/build.py
+++ b/cabotage/celery/tasks/build.py
@@ -955,6 +955,15 @@ def build_cache_pvc_name(app_env):
     return name
 
 
+def build_cache_pvc_labels(app_env):
+    """Build labels for a build-cache PVC."""
+    labels = _safe_labels_from_application(app_env.application)
+    if app_env.environment.uses_environment_namespace:
+        labels["cabotage.io/environment"] = app_env.environment.k8s_identifier
+    labels["cabotage.io/build-cache"] = "true"
+    return labels
+
+
 def fetch_image_build_cache_volume_claim(core_api_instance, buildable):
     namespace = _build_namespace(buildable.application_environment)
     volume_claim_name = build_cache_pvc_name(buildable.application_environment)
@@ -969,6 +978,9 @@ def fetch_image_build_cache_volume_claim(core_api_instance, buildable):
                 kubernetes.client.V1PersistentVolumeClaim(
                     metadata=kubernetes.client.V1ObjectMeta(
                         name=volume_claim_name,
+                        labels=build_cache_pvc_labels(
+                            buildable.application_environment
+                        ),
                     ),
                     spec=kubernetes.client.V1PersistentVolumeClaimSpec(
                         access_modes=["ReadWriteOncePod"],

--- a/tests/test_build_jobs.py
+++ b/tests/test_build_jobs.py
@@ -45,7 +45,9 @@ def _make_release(org_k8s="test-org", env_k8s="production", env_enabled=True):
     release.application.project.organization.slug = "test-org"
     release.application.project.organization.k8s_identifier = org_k8s
     release.application.project.slug = "test-project"
+    release.application.project.k8s_identifier = "test-project-d4e5f6"
     release.application.slug = "test-app"
+    release.application.k8s_identifier = "test-app-g7h8i9"
     release.version = 1
     release.build_job_id = "abc123"
     release.repository_name = "test-org/test-app"
@@ -63,7 +65,9 @@ def _make_image(org_k8s="test-org", env_k8s="production", env_enabled=True):
     image.application.project.organization.slug = "test-org"
     image.application.project.organization.k8s_identifier = org_k8s
     image.application.project.slug = "test-project"
+    image.application.project.k8s_identifier = "test-project-d4e5f6"
     image.application.slug = "test-app"
+    image.application.k8s_identifier = "test-app-g7h8i9"
     image.application.github_repository = "test-org/test-repo"
     image.application.github_repository_is_private = False
     image.application.github_app_installation_id = 12345
@@ -393,6 +397,28 @@ class TestBuildCachePVC:
 
         create_call = mock_core.create_namespaced_persistent_volume_claim.call_args
         assert create_call[0][0] == "cabotage-tenant-builds"
+
+    def test_pvc_created_with_safe_labels(self):
+        from kubernetes.client.rest import ApiException
+
+        image = _make_image(org_k8s="myorg", env_k8s="prod")
+        mock_core = MagicMock()
+        mock_core.read_namespaced_persistent_volume_claim.side_effect = ApiException(
+            status=404
+        )
+        mock_core.create_namespaced_persistent_volume_claim.return_value = MagicMock()
+
+        build_module.fetch_image_build_cache_volume_claim(mock_core, image)
+
+        create_call = mock_core.create_namespaced_persistent_volume_claim.call_args
+        pvc_object = create_call[0][1]
+        assert pvc_object.metadata.labels == {
+            "cabotage.io/organization": "myorg",
+            "cabotage.io/project": "test-project-d4e5f6",
+            "cabotage.io/application": "test-app-g7h8i9",
+            "cabotage.io/environment": "prod",
+            "cabotage.io/build-cache": "true",
+        }
 
     def test_pvc_read_in_tenant_namespace(self):
         image = _make_image(org_k8s="myorg", env_k8s="prod")

--- a/tests/test_pull_request_hook.py
+++ b/tests/test_pull_request_hook.py
@@ -1028,6 +1028,7 @@ class TestBranchDeployNamespaces:
             slug="pr-42",
         ).first()
         assert pr_environment is not None
+        pr_app_env = pr_environment.application_environments[0]
         cloned_pg = PostgresResource.query.filter_by(
             environment_id=pr_environment.id, slug="auth-db"
         ).first()
@@ -1040,10 +1041,22 @@ class TestBranchDeployNamespaces:
         pvc_one.metadata.name = "pgdata-auth-db-0"
         pvc_two = MagicMock()
         pvc_two.metadata.name = "pgdata-auth-db-1"
-        mock_core.list_namespaced_persistent_volume_claim.return_value.items = [
-            pvc_one,
-            pvc_two,
-        ]
+        build_cache_pvc = MagicMock()
+        from cabotage.celery.tasks.build import build_cache_pvc_name
+
+        build_cache_pvc.metadata.name = build_cache_pvc_name(pr_app_env)
+
+        def _list_pvcs(namespace, label_selector=None):
+            response = MagicMock()
+            if namespace == pr_environment.k8s_namespace:
+                response.items = [pvc_one, pvc_two]
+            elif namespace == "cabotage-tenant-builds":
+                response.items = [build_cache_pvc]
+            else:
+                response.items = []
+            return response
+
+        mock_core.list_namespaced_persistent_volume_claim.side_effect = _list_pvcs
         mock_core_api_cls.return_value = mock_core
         mock_delete_postgres = MagicMock()
 
@@ -1071,6 +1084,29 @@ class TestBranchDeployNamespaces:
             "pgdata-auth-db-0",
             "pgdata-auth-db-1",
         }
+        build_cache_calls = [
+            call
+            for call in mock_core.delete_namespaced_persistent_volume_claim.call_args_list
+            if call.args[1] == "cabotage-tenant-builds"
+        ]
+        assert {call.args[0] for call in build_cache_calls} == {
+            build_cache_pvc.metadata.name
+        }
+        build_cache_list_calls = [
+            call
+            for call in mock_core.list_namespaced_persistent_volume_claim.call_args_list
+            if call.args[0] == "cabotage-tenant-builds"
+        ]
+        assert len(build_cache_list_calls) == 1
+        assert (
+            build_cache_list_calls[0].kwargs["label_selector"]
+            == f"cabotage.io/application={pr_app_env.application.k8s_identifier},"
+            "cabotage.io/build-cache=true,"
+            f"cabotage.io/environment={pr_environment.k8s_identifier},"
+            "cabotage.io/organization="
+            f"{branch_deploy_project.organization.k8s_identifier},"
+            f"cabotage.io/project={branch_deploy_project.k8s_identifier}"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
when builds were moved into the build-specific namespace, we stopped automatically clearing them!