### PR TITLE
 fix namespace interhit bug for forked environments

### DIFF
--- a/cabotage/celery/tasks/deploy.py
+++ b/cabotage/celery/tasks/deploy.py
@@ -817,8 +817,7 @@ def render_cabotage_enrollment(release):
     env = release.application_environment.environment
     forked_from = env.forked_from_environment
     if forked_from:
-        org_k8s = release.application.project.organization.k8s_identifier
-        base_ns = safe_k8s_name(org_k8s, forked_from.k8s_identifier)
+        base_ns = forked_from.k8s_namespace
         spec["inheritsFrom"] = [
             {
                 "namespace": base_ns,


### PR DESCRIPTION
re: https://cabotage.us-east-2.psfhosted.computer/projects/pyladies/pyladiescon-portal/applications/pyladiescon-portal/deployments/845b85be-80e5-47dd-adc0-d48b4e5335d1

Seems like these fail because of a bug with namespacing whenever its a fork of an existing env