### PR TITLE
Make app settings safer

### DIFF
--- a/cabotage/client/templates/_macros.html
+++ b/cabotage/client/templates/_macros.html
@@ -256,7 +256,7 @@
           <span class="tab-label">Settings {{ icon('chevron-down', 'w-3 h-3 opacity-40') }}</span>
         </div>
         <ul tabindex="0" class="menu menu-md dropdown-content bg-base-100 rounded-box z-50 mt-1 w-52 p-2 shadow-lg border border-base-300">
-          <li><a href="{{ url_for('user.project_application_settings', org_slug=org_slug, project_slug=project_slug, app_slug=app_slug) }}"
+          <li><a href="{{ url_for('user.project_application_settings', org_slug=org_slug, project_slug=project_slug, app_slug=app_slug, env_slug=env_slug) }}"
                  class="{% if active == 'settings' %}active{% endif %}">{{ icon('box', 'w-3.5 h-3.5') }} Application</a></li>
           <li><a href="{{ url_for('user.project_application_environment_settings', org_slug=org_slug, project_slug=project_slug, env_slug=env_slug, app_slug=app_slug) }}"
                  class="{% if active == 'env_settings' %}active{% endif %}">{{ icon('layers', 'w-3.5 h-3.5') }} Environment</a></li>
@@ -737,7 +737,8 @@
   </script>
 {% endmacro %}
 
-{% macro danger_zone_delete(modal_id, title, confirm_slug, form, action_url, description='', impact_items=[]) %}
+{# Collapsible Danger Zone shell; caller() supplies the actions. #}
+{% macro danger_zone(description='') %}
   <div class="collapse collapse-arrow bg-error/5 border border-error/20 rounded-lg mt-6">
     <input type="checkbox" />
     <div class="collapse-title text-sm font-medium text-error">
@@ -745,13 +746,19 @@
     </div>
     <div class="collapse-content">
       <p class="text-sm text-base-content/60 mb-3">{{ description or 'This action cannot be undone.' }}</p>
-      <button type="button" class="btn btn-error btn-sm gap-1.5"
-              onclick="document.getElementById('{{ modal_id }}').showModal()">
-        {{ icon('trash-2', 'w-3.5 h-3.5') }}
-        {{ title }}
-      </button>
+      {{ caller() }}
     </div>
   </div>
+{% endmacro %}
+
+{% macro danger_zone_delete(modal_id, title, confirm_slug, form, action_url, description='', impact_items=[]) %}
+  {% call danger_zone(description) %}
+    <button type="button" class="btn btn-error btn-sm gap-1.5"
+            onclick="document.getElementById('{{ modal_id }}').showModal()">
+      {{ icon('trash-2', 'w-3.5 h-3.5') }}
+      {{ title }}
+    </button>
+  {% endcall %}
 
   <dialog id="{{ modal_id }}" class="modal">
     <div class="modal-box">

--- a/cabotage/client/templates/user/project_application.html
+++ b/cabotage/client/templates/user/project_application.html
@@ -28,6 +28,7 @@
 {% set org_slug = application.project.organization.slug %}
 {% set project_slug = application.project.slug %}
 {% set app_slug = application.slug %}
+{% set env_slug = environment.slug if environment else none %}
 
 {% block title %}
   {{ app_slug }} - Cabotage
@@ -173,14 +174,14 @@
             {% if not application.github_repository %}
               <p>{{ icon('alert-circle', 'w-3.5 h-3.5 text-warning') }} No repository connected</p>
               <p>Connect a GitHub repository to enable deployments.</p>
-              <a href="{{ url_for('user.project_application_settings', org_slug=org_slug, project_slug=project_slug, app_slug=app_slug) }}">{{ icon('settings', 'w-3 h-3') }} Go to Settings</a>
+              <a href="{{ url_for('user.project_application_settings', org_slug=org_slug, project_slug=project_slug, app_slug=app_slug, env_slug=env_slug) }}">{{ icon('settings', 'w-3 h-3') }} Go to Settings</a>
             {% elif not app_env %}
               <p>{{ icon('alert-circle', 'w-3.5 h-3.5 text-warning') }} No environment</p>
               <p>Add this application to an environment first.</p>
             {% else %}
               <p>{{ icon('alert-circle', 'w-3.5 h-3.5 text-warning') }} No deploy branch configured</p>
               <p>Set an auto-deploy branch in settings to enable one-click deploys.</p>
-              <a href="{{ url_for('user.project_application_settings', org_slug=org_slug, project_slug=project_slug, app_slug=app_slug) }}">{{ icon('settings', 'w-3 h-3') }} Go to Settings</a>
+              <a href="{{ url_for('user.project_application_settings', org_slug=org_slug, project_slug=project_slug, app_slug=app_slug, env_slug=env_slug) }}">{{ icon('settings', 'w-3 h-3') }} Go to Settings</a>
             {% endif %}
           </div>
         </div>
@@ -295,7 +296,7 @@
                   <div class="deploy-step-content">
                     <p class="text-sm font-medium text-base-content">Configure your repository</p>
                     <p class="text-xs text-base-content/40">Connect a GitHub repository to build from</p>
-                    <a href="{{ url_for('user.project_application_settings', org_slug=org_slug, project_slug=project_slug, app_slug=app_slug) }}"
+                    <a href="{{ url_for('user.project_application_settings', org_slug=org_slug, project_slug=project_slug, app_slug=app_slug, env_slug=env_slug) }}"
                        class="btn btn-primary btn-sm gap-1.5 mt-2">{{ icon('settings', 'w-3.5 h-3.5') }} Configure Repo</a>
                   </div>
                 </div>
@@ -1188,7 +1189,7 @@
         {% endif %}
       </div>
       {% if not application.github_repository %}
-        <a href="{{ url_for('user.project_application_settings', org_slug=org_slug, project_slug=project_slug, app_slug=app_slug) }}"
+        <a href="{{ url_for('user.project_application_settings', org_slug=org_slug, project_slug=project_slug, app_slug=app_slug, env_slug=env_slug) }}"
            class="pipeline-stage-body group">
           <span class="text-sm text-base-content/50">No repo configured</span>
         </a>
@@ -1207,7 +1208,7 @@
       {% endif %}
       <div class="pipeline-stage-action flex gap-1">
         {% if not application.github_repository %}
-          <a href="{{ url_for('user.project_application_settings', org_slug=org_slug, project_slug=project_slug, app_slug=app_slug) }}"
+          <a href="{{ url_for('user.project_application_settings', org_slug=org_slug, project_slug=project_slug, app_slug=app_slug, env_slug=env_slug) }}"
              class="btn btn-ghost btn-xs flex-1 gap-1">{{ icon('settings', 'w-3 h-3') }} Configure repo</a>
         {% else %}
           <a href="{{ url_for('user.application_images', org_slug=org_slug, project_slug=project_slug, app_slug=app_slug, env_slug=environment.slug if environment else none) }}"

--- a/cabotage/client/templates/user/project_application_settings.html
+++ b/cabotage/client/templates/user/project_application_settings.html
@@ -1,9 +1,11 @@
 {% extends "_base.html" %}
-{% from "_macros.html" import render_field_compact, icon, resource_path, app_tab_nav, app_resource_path, danger_zone_delete %}
+{% from "_macros.html" import render_field_compact, icon, resource_path, app_tab_nav, app_resource_path, danger_zone, danger_zone_delete %}
 
 {% set org_slug = application.project.organization.slug %}
 {% set project_slug = application.project.slug %}
 {% set app_slug = application.slug %}
+{# env_context is set only when the user navigated here from an environment #}
+{% set env_url = url_for('user.project_application_environment_settings', org_slug=org_slug, project_slug=project_slug, env_slug=env_context.environment.slug, app_slug=app_slug) if env_context else none %}
 
 {% block title %}
   Settings - {{ app_slug }} - Cabotage
@@ -24,7 +26,19 @@
       <div class="flex items-center gap-3">
         <div>
           <h1 class="text-xl font-semibold text-base-content">Application Settings</h1>
-          <p class="text-sm text-base-content/40">Configure how your application builds, deploys, and stays healthy</p>
+          <p class="text-sm text-base-content/40">
+            Configure how your application builds, deploys, and stays healthy.
+            {% if env_context %}
+              These apply to <span class="text-base-content/60">every environment</span>.
+              {% set overridden = env_context.overridden_settings %}
+              {% if overridden %}
+                <span class="text-warning">{{ env_context.environment.name }} overrides {{ overridden|join(', ') }}</span> —
+                <a class="link link-hover text-accent" href="{{ env_url }}">edit those</a>.
+              {% else %}
+                <a class="link link-hover text-accent" href="{{ env_url }}">Override for {{ env_context.environment.name }}</a>.
+              {% endif %}
+            {% endif %}
+          </p>
         </div>
       </div>
       <button type="submit"
@@ -35,7 +49,7 @@
       </button>
     </div>
 
-    <form action="{{ url_for('user.project_application_settings', org_slug=application.project.organization.slug, project_slug=application.project.slug, app_slug=application.slug) }}"
+    <form action="{{ url_for('user.project_application_settings', org_slug=application.project.organization.slug, project_slug=application.project.slug, app_slug=application.slug, env_slug=env_context.environment.slug if env_context else none) }}"
           method="post"
           id="settings-form"
           name="project_application_settings_form">
@@ -104,6 +118,14 @@
               {% for error in form.github_repository.errors %}<p class="text-xs text-error mt-0.5">{{ error }}</p>{% endfor %}
             </fieldset>
             {{ render_field_compact(form.auto_deploy_branch, placeholder='main', label='Branch') }}
+            {% if env_context and env_context.auto_deploy_branch %}
+              <p class="text-xs text-warning mt-1">
+                {{ icon('alert-triangle', 'w-3 h-3 inline align-text-bottom') }}
+                {{ env_context.environment.name }} deploys
+                <code class="font-semibold">{{ env_context.auto_deploy_branch }}</code> instead, so this
+                does not affect it — <a class="link link-hover" href="{{ env_url }}">edit the override</a>.
+              </p>
+            {% endif %}
           </div>
           <div class="settings-field-grid-3">
             {{ render_field_compact(form.subdirectory, placeholder='/', label='Subdirectory') }}
@@ -152,7 +174,21 @@
       </div>
     </form>
 
-    {% if delete_form %}
+    {% if env_context %}
+      {# Viewed from inside an environment: don't offer an all-environments delete
+         here, it reads as "delete in test". Point at the two real actions. #}
+      {% call danger_zone('You are viewing ' ~ env_context.environment.name ~ '. Deleting the application affects every environment, so it lives on the application-wide settings page.') %}
+        <div class="flex flex-wrap gap-2">
+          <a class="btn btn-outline btn-error btn-sm gap-1.5" href="{{ env_url }}">
+            {{ icon('layers', 'w-3.5 h-3.5') }} Remove from {{ env_context.environment.name }} only
+          </a>
+          <a class="btn btn-ghost btn-sm gap-1.5 text-base-content/50"
+             href="{{ url_for('user.project_application_settings', org_slug=org_slug, project_slug=project_slug, app_slug=app_slug) }}">
+            {{ icon('trash-2', 'w-3.5 h-3.5') }} Delete across all environments
+          </a>
+        </div>
+      {% endcall %}
+    {% else %}
       {{ danger_zone_delete(
         modal_id='delete-app-modal',
         title='Delete Application',

--- a/cabotage/server/models/projects.py
+++ b/cabotage/server/models/projects.py
@@ -480,6 +480,23 @@ class ApplicationEnvironment(Model, Timestamp):
     def effective_health_check_host(self):
         return self.health_check_host or self.application.health_check_host
 
+    OVERRIDABLE_SETTINGS = (
+        ("auto_deploy_branch", "Branch"),
+        ("github_environment_name", "GitHub Environment"),
+        ("deployment_timeout", "Deploy Timeout"),
+        ("health_check_path", "Health Path"),
+        ("health_check_host", "Health Host"),
+    )
+
+    @property
+    def overridden_settings(self):
+        """Labels of the application settings this environment overrides."""
+        return [
+            label
+            for attr, label in self.OVERRIDABLE_SETTINGS
+            if getattr(self, attr) is not None
+        ]
+
 
 class Application(Model, Timestamp):
     __versioned__: dict = {}

--- a/cabotage/server/models/projects.py
+++ b/cabotage/server/models/projects.py
@@ -490,7 +490,7 @@ class ApplicationEnvironment(Model, Timestamp):
 
     @property
     def overridden_settings(self):
-        """Labels of the application settings this environment overrides."""
+        """Labels of the settings this environment overrides."""
         return [
             label
             for attr, label in self.OVERRIDABLE_SETTINGS

--- a/cabotage/server/user/github_installations.py
+++ b/cabotage/server/user/github_installations.py
@@ -25,17 +25,21 @@ def connect_state_serializer():
     )
 
 
-def install_state(organization, user_id, application=None):
+def install_state(organization, user_id, application=None, env_slug=None):
     payload = {
         "organization_id": str(organization.id),
         "user_id": str(user_id),
     }
     if application is not None:
         payload["application_id"] = str(application.id)
+    if env_slug:
+        payload["env_slug"] = env_slug
     return install_state_serializer().dumps(payload)
 
 
-def connect_state(organization, user_id, *, installation_id=None, application=None):
+def connect_state(
+    organization, user_id, *, installation_id=None, application=None, env_slug=None
+):
     payload = {
         "organization_id": str(organization.id),
         "user_id": str(user_id),
@@ -44,6 +48,8 @@ def connect_state(organization, user_id, *, installation_id=None, application=No
         payload["installation_id"] = str(installation_id)
     if application is not None:
         payload["application_id"] = str(application.id)
+    if env_slug:
+        payload["env_slug"] = env_slug
     return connect_state_serializer().dumps(payload)
 
 

--- a/cabotage/server/user/github_oauth.py
+++ b/cabotage/server/user/github_oauth.py
@@ -396,6 +396,7 @@ def _complete_verified_installation_connection(
                 org_slug=organization.slug,
                 project_slug=application.project.slug,
                 app_slug=application.slug,
+                env_slug=payload.get("env_slug"),
             )
         )
 

--- a/cabotage/server/user/views.py
+++ b/cabotage/server/user/views.py
@@ -429,6 +429,24 @@ def _lookup_app_context(org_slug, project_slug, app_slug, require_admin=False):
     return organization, project, application
 
 
+def _app_env_for_env_slug(application, env_slug):
+    """Best-effort ApplicationEnvironment for a display-only env hint.
+
+    Unlike _resolve_app_env this never aborts: an unknown or deleted slug just
+    means "no environment context".
+    """
+    if not env_slug:
+        return None
+    return next(
+        (
+            ae
+            for ae in application.active_application_environments
+            if ae.environment and ae.environment.slug == env_slug
+        ),
+        None,
+    )
+
+
 def _default_environment(project):
     """Return the default environment for breadcrumbs, or None."""
     if not project.environments_enabled:
@@ -4059,12 +4077,23 @@ def project_application_settings(org_slug, project_slug, app_slug):
         org_slug, project_slug, app_slug, require_admin=True
     )
 
+    # These settings are app-wide, but keep the environment the user navigated
+    # from so the breadcrumbs and tabs don't silently jump to the default one.
+    # Resolved leniently: a stale or unknown slug is only a display hint, so it
+    # must not 404 the page you would go to in order to fix things.
+    env_context = _app_env_for_env_slug(application, request.args.get("env_slug"))
+    environment = (
+        env_context.environment if env_context else _default_environment(project)
+    )
+
     form = _prepare_application_settings_form(application, org)
 
     if form.validate_on_submit():
         _validate_github_source_settings(form, application, org)
         if form.github_app_installation_id.errors or form.github_repository.errors:
-            return _render_application_settings(application, org, project, form)
+            return _render_application_settings(
+                application, org, form, environment, env_context
+            )
 
         previous_github_app_installation_id = application.github_app_installation_id
         previous_github_repository = application.github_repository
@@ -4088,7 +4117,6 @@ def project_application_settings(org_slug, project_slug, app_slug):
         )
         db.session.add(activity)
         db.session.commit()
-        environment = _default_environment(project)
         return redirect(
             url_for(
                 "user.project_application",
@@ -4099,7 +4127,9 @@ def project_application_settings(org_slug, project_slug, app_slug):
             )
         )
 
-    return _render_application_settings(application, org, project, form)
+    return _render_application_settings(
+        application, org, form, environment, env_context
+    )
 
 
 def _prepare_application_settings_form(application, org):
@@ -4252,8 +4282,12 @@ def _application_delete_context(application):
     return delete_form, delete_impact
 
 
-def _render_application_settings(application, org, project, form):
-    delete_form, delete_impact = _application_delete_context(application)
+def _render_application_settings(application, org, form, environment, env_context):
+    # The env-scoped view points at the two real destructive actions instead of
+    # offering an all-environments delete, so skip building that context.
+    delete_form, delete_impact = (
+        (None, None) if env_context else _application_delete_context(application)
+    )
     return render_template(
         "user/project_application_settings.html",
         application=application,
@@ -4266,7 +4300,8 @@ def _render_application_settings(application, org, project, form):
         github_repository_options=github_installations.repository_options_by_installation(
             org
         ),
-        environment=_default_environment(project),
+        environment=environment,
+        env_context=env_context,
         delete_form=delete_form,
         delete_impact=delete_impact,
     )

--- a/cabotage/server/user/views.py
+++ b/cabotage/server/user/views.py
@@ -960,8 +960,11 @@ def github_install_start(org_slug):
         ):
             abort(404)
 
+    # Keep the environment the user came from across the GitHub round trip,
+    # otherwise they land back on the default-environment settings page.
+    env_slug = request.args.get("env_slug")
     state = github_installations.install_state(
-        organization, current_user.id, application
+        organization, current_user.id, application, env_slug=env_slug
     )
     install_url = github_installations.install_url(state)
     if install_url is None:
@@ -973,6 +976,7 @@ def github_install_start(org_slug):
                     org_slug=organization.slug,
                     project_slug=application.project.slug,
                     app_slug=application.slug,
+                    env_slug=env_slug,
                 )
             )
         return redirect(
@@ -1049,6 +1053,7 @@ def github_install_callback():
             current_user.id,
             installation_id=installation_id,
             application=application,
+            env_slug=payload.get("env_slug"),
         )
     )
     if authorize_url is None:
@@ -4298,6 +4303,7 @@ def _render_application_settings(application, org, form, environment, env_contex
             "user.github_install_start",
             org_slug=org.slug,
             application_id=application.id,
+            env_slug=env_context.environment.slug if env_context else None,
         ),
         github_repository_options=github_installations.repository_options_by_installation(
             org

--- a/cabotage/server/user/views.py
+++ b/cabotage/server/user/views.py
@@ -430,11 +430,7 @@ def _lookup_app_context(org_slug, project_slug, app_slug, require_admin=False):
 
 
 def _app_env_for_env_slug(application, env_slug):
-    """Best-effort ApplicationEnvironment for a display-only env hint.
-
-    Unlike _resolve_app_env this never aborts: an unknown or deleted slug just
-    means "no environment context".
-    """
+    """ApplicationEnvironment for a display-only env hint; never aborts."""
     if not env_slug:
         return None
     return next(
@@ -445,6 +441,18 @@ def _app_env_for_env_slug(application, env_slug):
         ),
         None,
     )
+
+
+def _settings_env_context(application, project, env_slug):
+    """(environment, env_context) for app-wide settings.
+
+    env_context is the enrolment the user navigated from, or None; environment
+    falls back to the project default so breadcrumbs stay populated.
+    """
+    env_context = _app_env_for_env_slug(application, env_slug)
+    if env_context:
+        return env_context.environment, env_context
+    return _default_environment(project), None
 
 
 def _default_environment(project):
@@ -4077,13 +4085,8 @@ def project_application_settings(org_slug, project_slug, app_slug):
         org_slug, project_slug, app_slug, require_admin=True
     )
 
-    # These settings are app-wide, but keep the environment the user navigated
-    # from so the breadcrumbs and tabs don't silently jump to the default one.
-    # Resolved leniently: a stale or unknown slug is only a display hint, so it
-    # must not 404 the page you would go to in order to fix things.
-    env_context = _app_env_for_env_slug(application, request.args.get("env_slug"))
-    environment = (
-        env_context.environment if env_context else _default_environment(project)
+    environment, env_context = _settings_env_context(
+        application, project, request.args.get("env_slug")
     )
 
     form = _prepare_application_settings_form(application, org)
@@ -4283,8 +4286,7 @@ def _application_delete_context(application):
 
 
 def _render_application_settings(application, org, form, environment, env_context):
-    # The env-scoped view points at the two real destructive actions instead of
-    # offering an all-environments delete, so skip building that context.
+    # The env-scoped view links to the real destructive actions instead.
     delete_form, delete_impact = (
         (None, None) if env_context else _application_delete_context(application)
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,111 @@
+"""Shared fixtures. Modules may still override any of these locally."""
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+from cabotage.server import db
+from cabotage.server.models.auth import Organization
+from cabotage.server.models.projects import (
+    Application,
+    ApplicationEnvironment,
+    Environment,
+    Project,
+)
+from cabotage.server.wsgi import app as _app
+
+
+@pytest.fixture
+def app():
+    _app.config["TESTING"] = True
+    _app.config["WTF_CSRF_ENABLED"] = False
+    with _app.app_context():
+        yield _app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def db_session(app):
+    yield db.session
+    db.session.rollback()
+
+
+@pytest.fixture
+def org(db_session):
+    o = Organization(name="Test Org", slug=f"testorg-{uuid.uuid4().hex[:8]}")
+    db_session.add(o)
+    db_session.flush()
+    return o
+
+
+@pytest.fixture
+def project(db_session, org):
+    p = Project(name="Test Project", organization_id=org.id)
+    db_session.add(p)
+    db_session.flush()
+    return p
+
+
+@pytest.fixture
+def environment(db_session, project):
+    e = Environment(name="test", slug="test", project_id=project.id, ephemeral=False)
+    db_session.add(e)
+    db_session.flush()
+    return e
+
+
+@pytest.fixture
+def application(db_session, project):
+    a = Application(
+        name="webapp",
+        slug="webapp",
+        project_id=project.id,
+        auto_deploy_branch="main",
+    )
+    db_session.add(a)
+    db_session.flush()
+    return a
+
+
+@pytest.fixture
+def make_environment(db_session, project):
+    def _make(slug, name=None, **kwargs):
+        e = Environment(
+            name=name or slug,
+            slug=slug,
+            project_id=project.id,
+            ephemeral=False,
+            **kwargs,
+        )
+        db_session.add(e)
+        db_session.flush()
+        return e
+
+    return _make
+
+
+@pytest.fixture
+def make_app_env(db_session):
+    def _make(application, environment, **kwargs):
+        app_env = ApplicationEnvironment(
+            application_id=application.id,
+            environment_id=environment.id,
+            **kwargs,
+        )
+        db_session.add(app_env)
+        db_session.flush()
+        return app_env
+
+    return _make
+
+
+@pytest.fixture
+def no_k8s_cleanup():
+    """Deletion paths queue a Celery task; the semantics under test are DB-side."""
+    with patch("cabotage.server.user.views.cleanup_app_env_k8s") as task:
+        yield task

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,11 +25,6 @@ def app():
 
 
 @pytest.fixture
-def client(app):
-    return app.test_client()
-
-
-@pytest.fixture
 def db_session(app):
     yield db.session
     db.session.rollback()
@@ -53,7 +48,7 @@ def project(db_session, org):
 
 @pytest.fixture
 def environment(db_session, project):
-    e = Environment(name="test", slug="test", project_id=project.id, ephemeral=False)
+    e = Environment(name="default", project_id=project.id, ephemeral=False)
     db_session.add(e)
     db_session.flush()
     return e
@@ -61,12 +56,7 @@ def environment(db_session, project):
 
 @pytest.fixture
 def application(db_session, project):
-    a = Application(
-        name="webapp",
-        slug="webapp",
-        project_id=project.id,
-        auto_deploy_branch="main",
-    )
+    a = Application(name="webapp", slug="webapp", project_id=project.id)
     db_session.add(a)
     db_session.flush()
     return a
@@ -106,6 +96,6 @@ def make_app_env(db_session):
 
 @pytest.fixture
 def no_k8s_cleanup():
-    """Deletion paths queue a Celery task; the semantics under test are DB-side."""
-    with patch("cabotage.server.user.views.cleanup_app_env_k8s") as task:
-        yield task
+    """Deletion paths queue k8s cleanup; the semantics under test are DB-side."""
+    with patch("cabotage.server.user.views._enqueue_app_env_cleanup") as enqueue:
+        yield enqueue

--- a/tests/test_deletion_scope.py
+++ b/tests/test_deletion_scope.py
@@ -10,129 +10,80 @@ from cabotage.server.user.views import (
 
 
 @pytest.fixture
-def two_envs(make_environment):
-    return make_environment("test"), make_environment("production")
+def envs(make_environment):
+    return {slug: make_environment(slug) for slug in ("test", "production")}
 
 
 @pytest.fixture
-def enrolled(application, two_envs, make_app_env):
-    test_env, prod_env = two_envs
-    return {
-        "test": make_app_env(application, test_env, auto_deploy_branch="feature-x"),
-        "production": make_app_env(application, prod_env),
-    }
+def enrolled(application, envs, make_app_env):
+    return {slug: make_app_env(application, env) for slug, env in envs.items()}
+
+
+@pytest.fixture
+def unenrolled_from_test(db_session, org, enrolled, no_k8s_cleanup):
+    _soft_delete_app_env(enrolled["test"], org)
+    db_session.flush()
+    return enrolled
+
+
+@pytest.fixture
+def test_env_deleted(db_session, org, envs, enrolled, no_k8s_cleanup):
+    _soft_delete_environment(envs["test"], org)
+    db_session.flush()
+    return enrolled
+
+
+@pytest.fixture
+def application_deleted(db_session, org, application, enrolled, no_k8s_cleanup):
+    _soft_delete_application(application, org)
+    db_session.flush()
+    return enrolled
+
+
+def _enrolled_slugs(application):
+    return sorted(
+        ae.environment.slug for ae in application.active_application_environments
+    )
 
 
 class TestUnenrollFromOneEnvironment:
-    def test_leaves_the_application_alive(
-        self, db_session, org, application, enrolled, no_k8s_cleanup
-    ):
-        _soft_delete_app_env(enrolled["test"], org)
-        db_session.flush()
-
+    def test_leaves_the_application_alive(self, application, unenrolled_from_test):
         assert application.deleted_at is None
 
     def test_leaves_other_environments_enrolled(
-        self, db_session, org, application, enrolled, no_k8s_cleanup
+        self, application, unenrolled_from_test
     ):
-        _soft_delete_app_env(enrolled["test"], org)
-        db_session.flush()
+        assert _enrolled_slugs(application) == ["production"]
 
-        remaining = application.active_application_environments
-        assert [ae.environment.slug for ae in remaining] == ["production"]
-
-    def test_removes_only_the_named_enrolment(
-        self, db_session, org, enrolled, no_k8s_cleanup
-    ):
-        _soft_delete_app_env(enrolled["test"], org)
-        db_session.flush()
-
-        assert enrolled["test"].deleted_at is not None
-        assert enrolled["production"].deleted_at is None
+    def test_removes_only_the_named_enrolment(self, unenrolled_from_test):
+        assert unenrolled_from_test["test"].deleted_at is not None
+        assert unenrolled_from_test["production"].deleted_at is None
 
 
 class TestDeleteEnvironment:
-    def test_application_survives(
-        self, db_session, org, application, two_envs, enrolled, no_k8s_cleanup
-    ):
-        test_env, _ = two_envs
-
-        _soft_delete_environment(test_env, org)
-        db_session.flush()
-
+    def test_application_survives(self, application, test_env_deleted):
         assert application.deleted_at is None
 
-    def test_other_environment_untouched(
-        self, db_session, org, two_envs, enrolled, no_k8s_cleanup
-    ):
-        test_env, prod_env = two_envs
+    def test_other_environment_untouched(self, envs, test_env_deleted):
+        assert envs["production"].deleted_at is None
+        assert test_env_deleted["production"].deleted_at is None
 
-        _soft_delete_environment(test_env, org)
-        db_session.flush()
+    def test_drops_only_its_own_enrolments(self, application, test_env_deleted):
+        assert test_env_deleted["test"].deleted_at is not None
+        assert _enrolled_slugs(application) == ["production"]
 
-        assert prod_env.deleted_at is None
-        assert enrolled["production"].deleted_at is None
-
-    def test_drops_only_its_own_enrolments(
-        self, db_session, org, application, two_envs, enrolled, no_k8s_cleanup
-    ):
-        test_env, _ = two_envs
-
-        _soft_delete_environment(test_env, org)
-        db_session.flush()
-
-        assert enrolled["test"].deleted_at is not None
-        assert [
-            ae.environment.slug for ae in application.active_application_environments
-        ] == ["production"]
-
-    def test_project_and_sibling_env_remain_listed(
-        self, db_session, org, project, two_envs, enrolled, no_k8s_cleanup
-    ):
-        test_env, _ = two_envs
-
-        _soft_delete_environment(test_env, org)
-        db_session.flush()
-
+    def test_project_stays_and_lists_the_sibling(self, project, test_env_deleted):
         assert project.deleted_at is None
         assert [e.slug for e in project.active_environments] == ["production"]
 
 
 class TestDeleteApplication:
-    def test_removes_every_enrolment(
-        self, db_session, org, application, enrolled, no_k8s_cleanup
-    ):
-        _soft_delete_application(application, org)
-        db_session.flush()
-
+    def test_removes_every_enrolment(self, application, application_deleted):
         assert application.deleted_at is not None
         assert application.active_application_environments == []
-        assert enrolled["test"].deleted_at is not None
-        assert enrolled["production"].deleted_at is not None
+        assert application_deleted["test"].deleted_at is not None
+        assert application_deleted["production"].deleted_at is not None
 
-    def test_environments_themselves_survive(
-        self, db_session, org, application, two_envs, enrolled, no_k8s_cleanup
-    ):
-        test_env, prod_env = two_envs
-
-        _soft_delete_application(application, org)
-        db_session.flush()
-
-        assert test_env.deleted_at is None
-        assert prod_env.deleted_at is None
-
-    def test_blast_radius_is_wider_than_unenrolling(
-        self, db_session, org, application, enrolled, no_k8s_cleanup
-    ):
-        before = len(application.active_application_environments)
-        assert before == 2
-
-        _soft_delete_app_env(enrolled["test"], org)
-        db_session.flush()
-        assert len(application.active_application_environments) == 1
-        assert application.deleted_at is None
-
-        _soft_delete_application(application, org)
-        db_session.flush()
-        assert application.active_application_environments == []
-        assert application.deleted_at is not None
+    def test_environments_themselves_survive(self, envs, application_deleted):
+        assert envs["test"].deleted_at is None
+        assert envs["production"].deleted_at is None

--- a/tests/test_deletion_scope.py
+++ b/tests/test_deletion_scope.py
@@ -1,0 +1,138 @@
+"""Blast radius of the three deletion paths (issue #376)."""
+
+import pytest
+
+from cabotage.server.user.views import (
+    _soft_delete_app_env,
+    _soft_delete_application,
+    _soft_delete_environment,
+)
+
+
+@pytest.fixture
+def two_envs(make_environment):
+    return make_environment("test"), make_environment("production")
+
+
+@pytest.fixture
+def enrolled(application, two_envs, make_app_env):
+    test_env, prod_env = two_envs
+    return {
+        "test": make_app_env(application, test_env, auto_deploy_branch="feature-x"),
+        "production": make_app_env(application, prod_env),
+    }
+
+
+class TestUnenrollFromOneEnvironment:
+    def test_leaves_the_application_alive(
+        self, db_session, org, application, enrolled, no_k8s_cleanup
+    ):
+        _soft_delete_app_env(enrolled["test"], org)
+        db_session.flush()
+
+        assert application.deleted_at is None
+
+    def test_leaves_other_environments_enrolled(
+        self, db_session, org, application, enrolled, no_k8s_cleanup
+    ):
+        _soft_delete_app_env(enrolled["test"], org)
+        db_session.flush()
+
+        remaining = application.active_application_environments
+        assert [ae.environment.slug for ae in remaining] == ["production"]
+
+    def test_removes_only_the_named_enrolment(
+        self, db_session, org, enrolled, no_k8s_cleanup
+    ):
+        _soft_delete_app_env(enrolled["test"], org)
+        db_session.flush()
+
+        assert enrolled["test"].deleted_at is not None
+        assert enrolled["production"].deleted_at is None
+
+
+class TestDeleteEnvironment:
+    def test_application_survives(
+        self, db_session, org, application, two_envs, enrolled, no_k8s_cleanup
+    ):
+        test_env, _ = two_envs
+
+        _soft_delete_environment(test_env, org)
+        db_session.flush()
+
+        assert application.deleted_at is None
+
+    def test_other_environment_untouched(
+        self, db_session, org, two_envs, enrolled, no_k8s_cleanup
+    ):
+        test_env, prod_env = two_envs
+
+        _soft_delete_environment(test_env, org)
+        db_session.flush()
+
+        assert prod_env.deleted_at is None
+        assert enrolled["production"].deleted_at is None
+
+    def test_drops_only_its_own_enrolments(
+        self, db_session, org, application, two_envs, enrolled, no_k8s_cleanup
+    ):
+        test_env, _ = two_envs
+
+        _soft_delete_environment(test_env, org)
+        db_session.flush()
+
+        assert enrolled["test"].deleted_at is not None
+        assert [
+            ae.environment.slug for ae in application.active_application_environments
+        ] == ["production"]
+
+    def test_project_and_sibling_env_remain_listed(
+        self, db_session, org, project, two_envs, enrolled, no_k8s_cleanup
+    ):
+        test_env, _ = two_envs
+
+        _soft_delete_environment(test_env, org)
+        db_session.flush()
+
+        assert project.deleted_at is None
+        assert [e.slug for e in project.active_environments] == ["production"]
+
+
+class TestDeleteApplication:
+    def test_removes_every_enrolment(
+        self, db_session, org, application, enrolled, no_k8s_cleanup
+    ):
+        _soft_delete_application(application, org)
+        db_session.flush()
+
+        assert application.deleted_at is not None
+        assert application.active_application_environments == []
+        assert enrolled["test"].deleted_at is not None
+        assert enrolled["production"].deleted_at is not None
+
+    def test_environments_themselves_survive(
+        self, db_session, org, application, two_envs, enrolled, no_k8s_cleanup
+    ):
+        test_env, prod_env = two_envs
+
+        _soft_delete_application(application, org)
+        db_session.flush()
+
+        assert test_env.deleted_at is None
+        assert prod_env.deleted_at is None
+
+    def test_blast_radius_is_wider_than_unenrolling(
+        self, db_session, org, application, enrolled, no_k8s_cleanup
+    ):
+        before = len(application.active_application_environments)
+        assert before == 2
+
+        _soft_delete_app_env(enrolled["test"], org)
+        db_session.flush()
+        assert len(application.active_application_environments) == 1
+        assert application.deleted_at is None
+
+        _soft_delete_application(application, org)
+        db_session.flush()
+        assert application.active_application_environments == []
+        assert application.deleted_at is not None

--- a/tests/test_env_settings_context.py
+++ b/tests/test_env_settings_context.py
@@ -1,0 +1,179 @@
+"""Tests for the environment hint on application-wide settings (issue #376).
+
+Application settings are app-wide, but the page keeps the environment the user
+navigated from. Two pieces make that safe: a lenient resolver that never aborts
+on a stale slug, and the model reporting which settings the environment
+overrides so the page can say the value being edited won't apply there.
+"""
+
+import uuid
+
+import pytest
+
+from cabotage.server import db
+from cabotage.server.models.auth import Organization
+from cabotage.server.models.projects import (
+    Application,
+    ApplicationEnvironment,
+    Environment,
+    Project,
+)
+from cabotage.server.user.views import _app_env_for_env_slug
+from cabotage.server.wsgi import app as _app
+
+
+@pytest.fixture
+def app():
+    _app.config["TESTING"] = True
+    _app.config["WTF_CSRF_ENABLED"] = False
+    with _app.app_context():
+        yield _app
+
+
+@pytest.fixture
+def db_session(app):
+    yield db.session
+    db.session.rollback()
+
+
+@pytest.fixture
+def org(db_session):
+    o = Organization(name="Test Org", slug=f"testorg-{uuid.uuid4().hex[:8]}")
+    db_session.add(o)
+    db_session.flush()
+    return o
+
+
+@pytest.fixture
+def project(db_session, org):
+    p = Project(name="Test Project", organization_id=org.id)
+    db_session.add(p)
+    db_session.flush()
+    return p
+
+
+@pytest.fixture
+def environment(db_session, project):
+    e = Environment(name="test", slug="test", project_id=project.id, ephemeral=False)
+    db_session.add(e)
+    db_session.flush()
+    return e
+
+
+@pytest.fixture
+def application(db_session, project):
+    a = Application(
+        name="webapp",
+        slug="webapp",
+        project_id=project.id,
+        auto_deploy_branch="main",
+    )
+    db_session.add(a)
+    db_session.flush()
+    return a
+
+
+def _make_app_env(application, environment, **kwargs):
+    app_env = ApplicationEnvironment(
+        application_id=application.id,
+        environment_id=environment.id,
+        **kwargs,
+    )
+    db.session.add(app_env)
+    db.session.flush()
+    return app_env
+
+
+class TestAppEnvForEnvSlug:
+    """The hint is display-only, so resolution must degrade, never abort."""
+
+    def test_resolves_a_known_slug(self, db_session, application, environment):
+        app_env = _make_app_env(application, environment)
+
+        result = _app_env_for_env_slug(application, "test")
+
+        assert result is not None
+        assert result.id == app_env.id
+
+    def test_unknown_slug_returns_none(self, db_session, application, environment):
+        _make_app_env(application, environment)
+
+        # A stale bookmark or a deleted environment must not 404 the settings
+        # page — that is the page you would go to in order to fix things.
+        assert _app_env_for_env_slug(application, "no-such-env") is None
+
+    @pytest.mark.parametrize("slug", [None, ""])
+    def test_missing_slug_returns_none(
+        self, db_session, application, environment, slug
+    ):
+        _make_app_env(application, environment)
+
+        assert _app_env_for_env_slug(application, slug) is None
+
+    def test_ignores_soft_deleted_enrollment(
+        self, db_session, application, environment
+    ):
+        import datetime
+
+        _make_app_env(
+            application,
+            environment,
+            deleted_at=datetime.datetime.now(datetime.timezone.utc),
+        )
+
+        assert _app_env_for_env_slug(application, "test") is None
+
+
+class TestOverriddenSettings:
+    """What the app-wide page reports as diverging for this environment."""
+
+    def test_no_overrides_reports_nothing(self, db_session, application, environment):
+        app_env = _make_app_env(application, environment)
+
+        assert app_env.overridden_settings == []
+
+    def test_reports_only_the_overridden_labels(
+        self, db_session, application, environment
+    ):
+        app_env = _make_app_env(
+            application,
+            environment,
+            auto_deploy_branch="feature-x",
+            deployment_timeout=600,
+        )
+
+        assert app_env.overridden_settings == ["Branch", "Deploy Timeout"]
+
+    def test_reports_every_overridable_column(
+        self, db_session, application, environment
+    ):
+        app_env = _make_app_env(
+            application,
+            environment,
+            auto_deploy_branch="feature-x",
+            github_environment_name="test-env",
+            deployment_timeout=600,
+            health_check_path="/healthz",
+            health_check_host="example.com",
+        )
+
+        assert app_env.overridden_settings == [
+            label for _, label in ApplicationEnvironment.OVERRIDABLE_SETTINGS
+        ]
+
+    def test_labels_stay_in_step_with_the_effective_properties(self):
+        """Every overridable column needs an effective_* counterpart, or the
+        page would claim an override that nothing actually reads."""
+        for attr, _ in ApplicationEnvironment.OVERRIDABLE_SETTINGS:
+            assert hasattr(ApplicationEnvironment, f"effective_{attr}")
+
+    def test_branch_override_means_the_app_value_is_not_used(
+        self, db_session, application, environment
+    ):
+        app_env = _make_app_env(
+            application, environment, auto_deploy_branch="feature-x"
+        )
+
+        assert "Branch" in app_env.overridden_settings
+        assert app_env.effective_auto_deploy_branch == "feature-x"
+        assert application.auto_deploy_branch == "main"

--- a/tests/test_env_settings_context.py
+++ b/tests/test_env_settings_context.py
@@ -5,64 +5,86 @@ dropped you into the default environment, where delete removes the application
 from every environment.
 """
 
+import datetime
 from unittest.mock import patch
 
 import pytest
 
 from cabotage.server.models.projects import ApplicationEnvironment
+from cabotage.server.user import github_installations
 from cabotage.server.user.views import (
     _app_env_for_env_slug,
     _render_application_settings,
     _settings_env_context,
 )
 
+ALL_OVERRIDES = {
+    "auto_deploy_branch": "feature-x",
+    "github_environment_name": "test-env",
+    "deployment_timeout": 600,
+    "health_check_path": "/healthz",
+    "health_check_host": "example.com",
+}
+
 
 @pytest.fixture
-def env_project(db_session, project):
+def env_project(project):
     """#376 only arises in environment-enabled projects."""
     project.environments_enabled = True
-    db_session.flush()
     return project
 
 
 @pytest.fixture
-def prod_and_staging(make_environment):
-    return (
-        make_environment("production", is_default=True),
-        make_environment("staging"),
-    )
+def envs(make_environment):
+    return {
+        "production": make_environment("production", is_default=True),
+        "staging": make_environment("staging"),
+    }
 
 
 @pytest.fixture
-def enrolled_everywhere(application, prod_and_staging, make_app_env):
-    prod, staging = prod_and_staging
-    return {
-        "production": make_app_env(application, prod),
-        "staging": make_app_env(application, staging),
-    }
+def enrolled(application, envs, make_app_env):
+    return {slug: make_app_env(application, env) for slug, env in envs.items()}
+
+
+@pytest.fixture
+def render_context(app, org, application):
+    """Context handed to the settings template for a given env context."""
+
+    def _render(environment, env_context):
+        with (
+            app.test_request_context("/"),
+            patch("cabotage.server.user.views.render_template") as render_template,
+        ):
+            _render_application_settings(
+                application, org, None, environment, env_context
+            )
+        return render_template.call_args.kwargs
+
+    return _render
 
 
 class TestSettingsEnvContext:
     def test_keeps_the_environment_you_came_from(
-        self, db_session, application, env_project, enrolled_everywhere
+        self, application, env_project, enrolled
     ):
         environment, env_context = _settings_env_context(
             application, env_project, "staging"
         )
 
         assert environment.slug == "staging"
-        assert env_context is enrolled_everywhere["staging"]
+        assert env_context is enrolled["staging"]
 
     def test_arriving_without_an_environment_uses_the_default(
-        self, db_session, application, env_project, enrolled_everywhere
+        self, application, env_project, enrolled
     ):
         environment, env_context = _settings_env_context(application, env_project, None)
 
         assert environment.slug == "production"
         assert env_context is None
 
-    def test_unknown_environment_degrades_instead_of_aborting(
-        self, db_session, application, env_project, enrolled_everywhere
+    def test_unknown_environment_falls_back_instead_of_aborting(
+        self, application, env_project, enrolled
     ):
         environment, env_context = _settings_env_context(
             application, env_project, "deleted-env"
@@ -71,131 +93,129 @@ class TestSettingsEnvContext:
         assert environment.slug == "production"
         assert env_context is None
 
-    def test_environment_the_app_is_not_enrolled_in_is_ignored(
-        self, db_session, application, env_project, prod_and_staging, make_app_env
-    ):
-        prod, _staging = prod_and_staging
-        make_app_env(application, prod)
-
-        environment, env_context = _settings_env_context(
-            application, env_project, "staging"
-        )
-
-        assert environment.slug == "production"
-        assert env_context is None
-
 
 class TestDeleteIsOnlyOfferedAppWide:
-    def _render_context(self, app, application, org, environment, env_context):
-        with app.test_request_context("/"):
-            with patch("cabotage.server.user.views.render_template") as render_template:
-                _render_application_settings(
-                    application, org, None, environment, env_context
-                )
-        return render_template.call_args.kwargs
-
     def test_withheld_when_viewing_from_an_environment(
-        self, app, db_session, org, application, env_project, enrolled_everywhere
+        self, application, env_project, enrolled, render_context
     ):
         environment, env_context = _settings_env_context(
             application, env_project, "staging"
         )
 
-        ctx = self._render_context(app, application, org, environment, env_context)
+        ctx = render_context(environment, env_context)
 
         assert ctx["delete_form"] is None
         assert ctx["delete_impact"] is None
         assert ctx["env_context"] is env_context
 
     def test_offered_on_the_app_wide_page(
-        self, app, db_session, org, application, env_project, enrolled_everywhere
+        self, application, env_project, enrolled, render_context
     ):
         environment, env_context = _settings_env_context(application, env_project, None)
 
-        ctx = self._render_context(app, application, org, environment, env_context)
+        ctx = render_context(environment, env_context)
 
         assert ctx["delete_form"] is not None
         assert ctx["env_context"] is None
 
 
+class TestGitHubInstallKeepsTheEnvironment:
+    """The install round trip must not drop you back into the default env."""
+
+    def test_install_link_carries_the_environment(
+        self, application, env_project, enrolled, render_context
+    ):
+        environment, env_context = _settings_env_context(
+            application, env_project, "staging"
+        )
+
+        ctx = render_context(environment, env_context)
+
+        assert "env_slug=staging" in ctx["app_url"]
+
+    def test_install_link_has_no_environment_when_app_wide(
+        self, application, env_project, enrolled, render_context
+    ):
+        environment, env_context = _settings_env_context(application, env_project, None)
+
+        ctx = render_context(environment, env_context)
+
+        assert "env_slug" not in ctx["app_url"]
+
+    @pytest.mark.parametrize(
+        ("kwargs", "expected"),
+        [({"env_slug": "staging"}, "staging"), ({}, None)],
+        ids=["from an environment", "app-wide"],
+    )
+    def test_signed_state_round_trips_the_environment(self, app, org, kwargs, expected):
+        with app.test_request_context("/"):
+            state = github_installations.install_state(org, "a-user-id", **kwargs)
+            payload = github_installations.install_state_serializer().loads(state)
+
+        assert payload.get("env_slug") == expected
+
+
 class TestAppEnvForEnvSlug:
     """Display-only hint: resolution degrades, never aborts."""
 
-    def test_resolves_a_known_slug(
-        self, db_session, application, environment, make_app_env
-    ):
+    def test_resolves_a_known_slug(self, application, environment, make_app_env):
         app_env = make_app_env(application, environment)
 
-        result = _app_env_for_env_slug(application, "test")
+        assert _app_env_for_env_slug(application, "default") is app_env
 
-        assert result is not None
-        assert result.id == app_env.id
-
-    def test_unknown_slug_returns_none(
-        self, db_session, application, environment, make_app_env
-    ):
+    def test_unknown_slug_returns_none(self, application, environment, make_app_env):
         make_app_env(application, environment)
 
         assert _app_env_for_env_slug(application, "no-such-env") is None
 
     @pytest.mark.parametrize("slug", [None, ""])
     def test_missing_slug_returns_none(
-        self, db_session, application, environment, make_app_env, slug
+        self, application, environment, make_app_env, slug
     ):
         make_app_env(application, environment)
 
         assert _app_env_for_env_slug(application, slug) is None
 
     def test_ignores_soft_deleted_enrolment(
-        self, db_session, application, environment, make_app_env
+        self, application, environment, make_app_env
     ):
-        import datetime
-
         make_app_env(
             application,
             environment,
             deleted_at=datetime.datetime.now(datetime.timezone.utc),
         )
 
-        assert _app_env_for_env_slug(application, "test") is None
+        assert _app_env_for_env_slug(application, "default") is None
 
 
 class TestOverriddenSettings:
-    def test_no_overrides_reports_nothing(
-        self, db_session, application, environment, make_app_env
+    @pytest.mark.parametrize(
+        ("overrides", "expected"),
+        [
+            ({}, []),
+            (
+                {"auto_deploy_branch": "feature-x", "deployment_timeout": 600},
+                ["Branch", "Deploy Timeout"],
+            ),
+            (
+                ALL_OVERRIDES,
+                [
+                    "Branch",
+                    "GitHub Environment",
+                    "Deploy Timeout",
+                    "Health Path",
+                    "Health Host",
+                ],
+            ),
+        ],
+        ids=["none", "some", "all"],
+    )
+    def test_reports_overridden_labels(
+        self, application, environment, make_app_env, overrides, expected
     ):
-        app_env = make_app_env(application, environment)
+        app_env = make_app_env(application, environment, **overrides)
 
-        assert app_env.overridden_settings == []
-
-    def test_reports_only_the_overridden_labels(
-        self, db_session, application, environment, make_app_env
-    ):
-        app_env = make_app_env(
-            application,
-            environment,
-            auto_deploy_branch="feature-x",
-            deployment_timeout=600,
-        )
-
-        assert app_env.overridden_settings == ["Branch", "Deploy Timeout"]
-
-    def test_reports_every_overridable_column(
-        self, db_session, application, environment, make_app_env
-    ):
-        app_env = make_app_env(
-            application,
-            environment,
-            auto_deploy_branch="feature-x",
-            github_environment_name="test-env",
-            deployment_timeout=600,
-            health_check_path="/healthz",
-            health_check_host="example.com",
-        )
-
-        assert app_env.overridden_settings == [
-            label for _, label in ApplicationEnvironment.OVERRIDABLE_SETTINGS
-        ]
+        assert app_env.overridden_settings == expected
 
     def test_labels_stay_in_step_with_the_effective_properties(self):
         """An override nothing reads would be a lie on the page."""
@@ -205,6 +225,8 @@ class TestOverriddenSettings:
     def test_branch_override_means_the_app_value_is_not_used(
         self, db_session, application, environment, make_app_env
     ):
+        application.auto_deploy_branch = "main"
+        db_session.flush()
         app_env = make_app_env(application, environment, auto_deploy_branch="feature-x")
 
         assert "Branch" in app_env.overridden_settings

--- a/tests/test_env_settings_context.py
+++ b/tests/test_env_settings_context.py
@@ -1,121 +1,157 @@
-"""Tests for the environment hint on application-wide settings (issue #376).
+"""Environment context on application-wide settings (issue #376).
 
-Application settings are app-wide, but the page keeps the environment the user
-navigated from. Two pieces make that safe: a lenient resolver that never aborts
-on a stale slug, and the model reporting which settings the environment
-overrides so the page can say the value being edited won't apply there.
+Reported: from a non-default environment, Settings -> Application Settings
+dropped you into the default environment, where delete removes the application
+from every environment.
 """
 
-import uuid
+from unittest.mock import patch
 
 import pytest
 
-from cabotage.server import db
-from cabotage.server.models.auth import Organization
-from cabotage.server.models.projects import (
-    Application,
-    ApplicationEnvironment,
-    Environment,
-    Project,
+from cabotage.server.models.projects import ApplicationEnvironment
+from cabotage.server.user.views import (
+    _app_env_for_env_slug,
+    _render_application_settings,
+    _settings_env_context,
 )
-from cabotage.server.user.views import _app_env_for_env_slug
-from cabotage.server.wsgi import app as _app
 
 
 @pytest.fixture
-def app():
-    _app.config["TESTING"] = True
-    _app.config["WTF_CSRF_ENABLED"] = False
-    with _app.app_context():
-        yield _app
-
-
-@pytest.fixture
-def db_session(app):
-    yield db.session
-    db.session.rollback()
-
-
-@pytest.fixture
-def org(db_session):
-    o = Organization(name="Test Org", slug=f"testorg-{uuid.uuid4().hex[:8]}")
-    db_session.add(o)
+def env_project(db_session, project):
+    """#376 only arises in environment-enabled projects."""
+    project.environments_enabled = True
     db_session.flush()
-    return o
+    return project
 
 
 @pytest.fixture
-def project(db_session, org):
-    p = Project(name="Test Project", organization_id=org.id)
-    db_session.add(p)
-    db_session.flush()
-    return p
-
-
-@pytest.fixture
-def environment(db_session, project):
-    e = Environment(name="test", slug="test", project_id=project.id, ephemeral=False)
-    db_session.add(e)
-    db_session.flush()
-    return e
-
-
-@pytest.fixture
-def application(db_session, project):
-    a = Application(
-        name="webapp",
-        slug="webapp",
-        project_id=project.id,
-        auto_deploy_branch="main",
+def prod_and_staging(make_environment):
+    return (
+        make_environment("production", is_default=True),
+        make_environment("staging"),
     )
-    db_session.add(a)
-    db_session.flush()
-    return a
 
 
-def _make_app_env(application, environment, **kwargs):
-    app_env = ApplicationEnvironment(
-        application_id=application.id,
-        environment_id=environment.id,
-        **kwargs,
-    )
-    db.session.add(app_env)
-    db.session.flush()
-    return app_env
+@pytest.fixture
+def enrolled_everywhere(application, prod_and_staging, make_app_env):
+    prod, staging = prod_and_staging
+    return {
+        "production": make_app_env(application, prod),
+        "staging": make_app_env(application, staging),
+    }
+
+
+class TestSettingsEnvContext:
+    def test_keeps_the_environment_you_came_from(
+        self, db_session, application, env_project, enrolled_everywhere
+    ):
+        environment, env_context = _settings_env_context(
+            application, env_project, "staging"
+        )
+
+        assert environment.slug == "staging"
+        assert env_context is enrolled_everywhere["staging"]
+
+    def test_arriving_without_an_environment_uses_the_default(
+        self, db_session, application, env_project, enrolled_everywhere
+    ):
+        environment, env_context = _settings_env_context(application, env_project, None)
+
+        assert environment.slug == "production"
+        assert env_context is None
+
+    def test_unknown_environment_degrades_instead_of_aborting(
+        self, db_session, application, env_project, enrolled_everywhere
+    ):
+        environment, env_context = _settings_env_context(
+            application, env_project, "deleted-env"
+        )
+
+        assert environment.slug == "production"
+        assert env_context is None
+
+    def test_environment_the_app_is_not_enrolled_in_is_ignored(
+        self, db_session, application, env_project, prod_and_staging, make_app_env
+    ):
+        prod, _staging = prod_and_staging
+        make_app_env(application, prod)
+
+        environment, env_context = _settings_env_context(
+            application, env_project, "staging"
+        )
+
+        assert environment.slug == "production"
+        assert env_context is None
+
+
+class TestDeleteIsOnlyOfferedAppWide:
+    def _render_context(self, app, application, org, environment, env_context):
+        with app.test_request_context("/"):
+            with patch("cabotage.server.user.views.render_template") as render_template:
+                _render_application_settings(
+                    application, org, None, environment, env_context
+                )
+        return render_template.call_args.kwargs
+
+    def test_withheld_when_viewing_from_an_environment(
+        self, app, db_session, org, application, env_project, enrolled_everywhere
+    ):
+        environment, env_context = _settings_env_context(
+            application, env_project, "staging"
+        )
+
+        ctx = self._render_context(app, application, org, environment, env_context)
+
+        assert ctx["delete_form"] is None
+        assert ctx["delete_impact"] is None
+        assert ctx["env_context"] is env_context
+
+    def test_offered_on_the_app_wide_page(
+        self, app, db_session, org, application, env_project, enrolled_everywhere
+    ):
+        environment, env_context = _settings_env_context(application, env_project, None)
+
+        ctx = self._render_context(app, application, org, environment, env_context)
+
+        assert ctx["delete_form"] is not None
+        assert ctx["env_context"] is None
 
 
 class TestAppEnvForEnvSlug:
-    """The hint is display-only, so resolution must degrade, never abort."""
+    """Display-only hint: resolution degrades, never aborts."""
 
-    def test_resolves_a_known_slug(self, db_session, application, environment):
-        app_env = _make_app_env(application, environment)
+    def test_resolves_a_known_slug(
+        self, db_session, application, environment, make_app_env
+    ):
+        app_env = make_app_env(application, environment)
 
         result = _app_env_for_env_slug(application, "test")
 
         assert result is not None
         assert result.id == app_env.id
 
-    def test_unknown_slug_returns_none(self, db_session, application, environment):
-        _make_app_env(application, environment)
+    def test_unknown_slug_returns_none(
+        self, db_session, application, environment, make_app_env
+    ):
+        make_app_env(application, environment)
 
-        # A stale bookmark or a deleted environment must not 404 the settings
-        # page — that is the page you would go to in order to fix things.
         assert _app_env_for_env_slug(application, "no-such-env") is None
 
     @pytest.mark.parametrize("slug", [None, ""])
     def test_missing_slug_returns_none(
-        self, db_session, application, environment, slug
+        self, db_session, application, environment, make_app_env, slug
     ):
-        _make_app_env(application, environment)
+        make_app_env(application, environment)
 
         assert _app_env_for_env_slug(application, slug) is None
 
-    def test_ignores_soft_deleted_enrollment(
-        self, db_session, application, environment
+    def test_ignores_soft_deleted_enrolment(
+        self, db_session, application, environment, make_app_env
     ):
         import datetime
 
-        _make_app_env(
+        make_app_env(
             application,
             environment,
             deleted_at=datetime.datetime.now(datetime.timezone.utc),
@@ -125,17 +161,17 @@ class TestAppEnvForEnvSlug:
 
 
 class TestOverriddenSettings:
-    """What the app-wide page reports as diverging for this environment."""
-
-    def test_no_overrides_reports_nothing(self, db_session, application, environment):
-        app_env = _make_app_env(application, environment)
+    def test_no_overrides_reports_nothing(
+        self, db_session, application, environment, make_app_env
+    ):
+        app_env = make_app_env(application, environment)
 
         assert app_env.overridden_settings == []
 
     def test_reports_only_the_overridden_labels(
-        self, db_session, application, environment
+        self, db_session, application, environment, make_app_env
     ):
-        app_env = _make_app_env(
+        app_env = make_app_env(
             application,
             environment,
             auto_deploy_branch="feature-x",
@@ -145,9 +181,9 @@ class TestOverriddenSettings:
         assert app_env.overridden_settings == ["Branch", "Deploy Timeout"]
 
     def test_reports_every_overridable_column(
-        self, db_session, application, environment
+        self, db_session, application, environment, make_app_env
     ):
-        app_env = _make_app_env(
+        app_env = make_app_env(
             application,
             environment,
             auto_deploy_branch="feature-x",
@@ -162,17 +198,14 @@ class TestOverriddenSettings:
         ]
 
     def test_labels_stay_in_step_with_the_effective_properties(self):
-        """Every overridable column needs an effective_* counterpart, or the
-        page would claim an override that nothing actually reads."""
+        """An override nothing reads would be a lie on the page."""
         for attr, _ in ApplicationEnvironment.OVERRIDABLE_SETTINGS:
             assert hasattr(ApplicationEnvironment, f"effective_{attr}")
 
     def test_branch_override_means_the_app_value_is_not_used(
-        self, db_session, application, environment
+        self, db_session, application, environment, make_app_env
     ):
-        app_env = _make_app_env(
-            application, environment, auto_deploy_branch="feature-x"
-        )
+        app_env = make_app_env(application, environment, auto_deploy_branch="feature-x")
 
         assert "Branch" in app_env.overridden_settings
         assert app_env.effective_auto_deploy_branch == "feature-x"


### PR DESCRIPTION
<!--  Thank you for sending a pull request! Please take a moment to answer the following questions:
- Have you read our [general contributing guide](./CONTRIBUTING.md)?
- Have you added or run the appropriate tests?
- Do the commit messages and bodies explain what and why?
- If your PR is not finished, please mark it as a draft.
☝️ Please **have another look at the files changed** before opening this PR. 🙏
-->

### Description

If I am in an environment-enabled project and swap off the main environment (`production` for example) to an arbitrary one (`test` or `staging` for example) and go to settings -> app settings it will actually drop you into the production environment.

This is a problem because the delete button there deletes all environments. Big surprise there.

Also, as a nice thing in passing i've added notation of currently active overrides

<img width="1074" height="170" alt="image" src="https://github.com/user-attachments/assets/d4b6e77e-9f3d-4fe8-a9cc-2e6e64d357fc" />
<img width="841" height="288" alt="image" src="https://github.com/user-attachments/assets/034b33ea-74da-4edf-8c73-d92b663597bf" />
<img width="1062" height="165" alt="image" src="https://github.com/user-attachments/assets/9a638421-1ae2-4709-bbb9-7e0f202bfe7e" />


Fixes #376 